### PR TITLE
Fixed anonymous struct completion

### DIFF
--- a/src/haxeLanguageServer/features/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/CompletionFeature.hx
@@ -43,7 +43,7 @@ class CompletionFeature {
                 pos: index - reFieldPart.matched(3).length,
                 toplevel: false,
             };
-        else if(reStructPart.match(text))
+        else if (reStructPart.match(text))
             return {
                 pos: index - reStructPart.matched(1).length,
                 toplevel: false,

--- a/src/haxeLanguageServer/features/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/CompletionFeature.hx
@@ -38,7 +38,6 @@ class CompletionFeature {
     static var reFieldPart = ~/(\.|@(:?))(\w*)$/;
     static var reStructPart = ~/[(,]\s*{\s*((\s*\w+\s*:\s*["'\w()\.]+\s*,\s*)*\w*)$/;
     static function calculateCompletionPosition(text:String, index:Int):CompletionPosition {
-        text = text.substring(0, index);
         if (reFieldPart.match(text))
             return {
                 pos: index - reFieldPart.matched(3).length,

--- a/src/haxeLanguageServer/features/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/CompletionFeature.hx
@@ -36,7 +36,7 @@ class CompletionFeature {
     }
 
     static var reFieldPart = ~/(\.|@(:?))(\w*)$/;
-    static var reStructPart = ~/[(,]\s*{\s*((\s*\w+\s*:\s*["'\w()\.]+\s*,\s*)*\w*)$/;
+    static var reStructPart = ~/[(,]\s*{(\s*(\s*\w+\s*:\s*["'\w()\.]+\s*,\s*)*\w*)$/;
     static function calculateCompletionPosition(text:String, index:Int):CompletionPosition {
         if (reFieldPart.match(text))
             return {

--- a/src/haxeLanguageServer/features/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/CompletionFeature.hx
@@ -36,12 +36,12 @@ class CompletionFeature {
     }
 
     static var reFieldPart = ~/(\.|@(:?))(\w*)$/;
-    static var reStructPart = ~/[(,]\s*{((\s*\w+\s*:\s*["'\w()\.]+\s*,\s*)*\w*)$/;
+    static var reStructPart = ~/[(,]\s*{\s*((\s*\w+\s*:\s*["'\w()\.]+\s*,\s*)*\w*)$/;
     static function calculateCompletionPosition(text:String, index:Int):CompletionPosition {
         text = text.substring(0, index);
         if (reFieldPart.match(text))
             return {
-                pos: index - reFieldPart.matched(2).length,
+                pos: index - reFieldPart.matched(3).length,
                 toplevel: false,
             };
         else if(reStructPart.match(text))

--- a/src/haxeLanguageServer/features/CompletionFeature.hx
+++ b/src/haxeLanguageServer/features/CompletionFeature.hx
@@ -36,10 +36,17 @@ class CompletionFeature {
     }
 
     static var reFieldPart = ~/(\.|@(:?))(\w*)$/;
+    static var reStructPart = ~/[(,]\s*{((\s*\w+\s*:\s*["'\w()\.]+\s*,\s*)*\w*)$/;
     static function calculateCompletionPosition(text:String, index:Int):CompletionPosition {
+        text = text.substring(0, index);
         if (reFieldPart.match(text))
             return {
-                pos: index - reFieldPart.matched(3).length,
+                pos: index - reFieldPart.matched(2).length,
+                toplevel: false,
+            };
+        else if(reStructPart.match(text))
+            return {
+                pos: index - reStructPart.matched(1).length,
                 toplevel: false,
             };
         else


### PR DESCRIPTION
I've put some research into the data the language server spits out and it seemed like the extension never gets informations about the field names.

The reason for this is, that the extension asks the language server for top level completion. The fix was pretty easy, I just had to edit the function which checks wether to use top level completion.

This should fix https://github.com/vshaxe/haxe-languageserver/issues/21