### PR TITLE
fix unhanded exceptions when calling server

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -187,6 +187,17 @@ class Context {
             "--no-output", // prevent anygeneration
         ]);
         actualArgs = actualArgs.concat(args); // finally, add given query args
-        haxeServer.process(actualArgs, token, stdin, callback, errback);
+        
+        // check for answer, it can be `null`
+        // this can occur when incorrect arguments
+        // e.g.: `config::haxe.displayServer.arguments = ["-ololo"]`
+        function precheck(s:String):Void
+            if(s != null)
+                callback(s);
+            else
+                //TODO: maybe here need to validate all User's preferences & arguments for server?
+                errback(s);
+        
+        haxeServer.process(actualArgs, token, stdin, precheck, errback);
     }
 }


### PR DESCRIPTION
Fix multiple unhanded exceptions when `haxe.displayServer.arguments` contains invalid/unsupported arguments or any another troubles.

With this hotfix it will be easier to find the problem with the server.

- - -

Prior to this hotfix, all Features was getting error in this places:
1. [CodeLensFeature.processStatisticsReply](https://github.com/vshaxe/haxe-languageserver/blob/master/src/haxeLanguageServer/features/CodeLensFeature.hx#L95)
1. [DiagnosticsManager.processDiagnosticsReply](https://github.com/vshaxe/haxe-languageserver/blob/master/src/haxeLanguageServer/features/DiagnosticsManager.hx#L38)

There is example:
```
Initializing completion cache...
Restarting Haxe completion server: Haxe process was killed
Could not retrieve haxelib repo path for diagnostics filtering
/Users/ak/Developer/Projects/vshaxe/bin/server.js:2497
		while(_g < data.length) {
		               ^
```