### PR TITLE
Use hxparser by default for document symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dump/
+Actual.json

--- a/cases/documentSymbols/Expected.json
+++ b/cases/documentSymbols/Expected.json
@@ -1,0 +1,632 @@
+[
+    {
+        "name": "Class",
+        "kind": 5,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 0,
+                    "character": 6
+                },
+                "end": {
+                    "line": 0,
+                    "character": 11
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "CONSTANT",
+        "kind": 14,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 1,
+                    "character": 22
+                },
+                "end": {
+                    "line": 1,
+                    "character": 30
+                }
+            }
+        },
+        "containerName": "Class"
+    },
+    {
+        "name": "variable",
+        "kind": 8,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 3,
+                    "character": 8
+                },
+                "end": {
+                    "line": 3,
+                    "character": 16
+                }
+            }
+        },
+        "containerName": "Class"
+    },
+    {
+        "name": "property",
+        "kind": 7,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 5,
+                    "character": 8
+                },
+                "end": {
+                    "line": 5,
+                    "character": 16
+                }
+            }
+        },
+        "containerName": "Class"
+    },
+    {
+        "name": "foo",
+        "kind": 12,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 13
+                },
+                "end": {
+                    "line": 7,
+                    "character": 16
+                }
+            }
+        },
+        "containerName": "Class"
+    },
+    {
+        "name": "param1",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 17
+                },
+                "end": {
+                    "line": 7,
+                    "character": 23
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "param2",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 7,
+                    "character": 29
+                },
+                "end": {
+                    "line": 7,
+                    "character": 35
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "foo2",
+        "kind": 12,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 8,
+                    "character": 17
+                },
+                "end": {
+                    "line": 8,
+                    "character": 21
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "foo3",
+        "kind": 12,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 9,
+                    "character": 21
+                },
+                "end": {
+                    "line": 9,
+                    "character": 25
+                }
+            }
+        },
+        "containerName": "Class.foo.foo2"
+    },
+    {
+        "name": "foo4",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 10,
+                    "character": 20
+                },
+                "end": {
+                    "line": 10,
+                    "character": 24
+                }
+            }
+        },
+        "containerName": "Class.foo.foo2.foo3"
+    },
+    {
+        "name": "foo",
+        "kind": 12,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 14,
+                    "character": 24
+                },
+                "end": {
+                    "line": 14,
+                    "character": 27
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "f",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 16,
+                    "character": 12
+                },
+                "end": {
+                    "line": 16,
+                    "character": 13
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "a",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 18,
+                    "character": 12
+                },
+                "end": {
+                    "line": 18,
+                    "character": 13
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "b",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 18,
+                    "character": 15
+                },
+                "end": {
+                    "line": 18,
+                    "character": 16
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "c",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 18,
+                    "character": 18
+                },
+                "end": {
+                    "line": 18,
+                    "character": 19
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "new",
+        "kind": 9,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 21,
+                    "character": 13
+                },
+                "end": {
+                    "line": 21,
+                    "character": 16
+                }
+            }
+        },
+        "containerName": "Class"
+    },
+    {
+        "name": "Interface",
+        "kind": 11,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 24,
+                    "character": 10
+                },
+                "end": {
+                    "line": 24,
+                    "character": 19
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "variable",
+        "kind": 8,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 25,
+                    "character": 8
+                },
+                "end": {
+                    "line": 25,
+                    "character": 16
+                }
+            }
+        },
+        "containerName": "Interface"
+    },
+    {
+        "name": "foo",
+        "kind": 12,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 26,
+                    "character": 13
+                },
+                "end": {
+                    "line": 26,
+                    "character": 16
+                }
+            }
+        },
+        "containerName": "Interface"
+    },
+    {
+        "name": "Abstract",
+        "kind": 5,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 29,
+                    "character": 9
+                },
+                "end": {
+                    "line": 29,
+                    "character": 17
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "CONSTANT",
+        "kind": 14,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 22
+                },
+                "end": {
+                    "line": 30,
+                    "character": 30
+                }
+            }
+        },
+        "containerName": "Abstract"
+    },
+    {
+        "name": "new",
+        "kind": 9,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 32,
+                    "character": 20
+                },
+                "end": {
+                    "line": 32,
+                    "character": 23
+                }
+            }
+        },
+        "containerName": "Abstract"
+    },
+    {
+        "name": "EnumAbstract",
+        "kind": 5,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 35,
+                    "character": 16
+                },
+                "end": {
+                    "line": 35,
+                    "character": 28
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "Value1",
+        "kind": 8,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 36,
+                    "character": 8
+                },
+                "end": {
+                    "line": 36,
+                    "character": 14
+                }
+            }
+        },
+        "containerName": "EnumAbstract"
+    },
+    {
+        "name": "Value2",
+        "kind": 8,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 37,
+                    "character": 8
+                },
+                "end": {
+                    "line": 37,
+                    "character": 14
+                }
+            }
+        },
+        "containerName": "EnumAbstract"
+    },
+    {
+        "name": "Enum",
+        "kind": 10,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 40,
+                    "character": 5
+                },
+                "end": {
+                    "line": 40,
+                    "character": 9
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "Simple",
+        "kind": 12,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 41,
+                    "character": 4
+                },
+                "end": {
+                    "line": 41,
+                    "character": 10
+                }
+            }
+        },
+        "containerName": "Enum"
+    },
+    {
+        "name": "Complex",
+        "kind": 12,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 42,
+                    "character": 4
+                },
+                "end": {
+                    "line": 42,
+                    "character": 11
+                }
+            }
+        },
+        "containerName": "Enum"
+    },
+    {
+        "name": "TypeAlias",
+        "kind": 11,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 45,
+                    "character": 8
+                },
+                "end": {
+                    "line": 45,
+                    "character": 17
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "TypedefShortFields",
+        "kind": 11,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 47,
+                    "character": 8
+                },
+                "end": {
+                    "line": 47,
+                    "character": 26
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "a",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 48,
+                    "character": 5
+                },
+                "end": {
+                    "line": 48,
+                    "character": 6
+                }
+            }
+        },
+        "containerName": "TypedefShortFields"
+    },
+    {
+        "name": "b",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 49,
+                    "character": 4
+                },
+                "end": {
+                    "line": 49,
+                    "character": 5
+                }
+            }
+        },
+        "containerName": "TypedefShortFields"
+    },
+    {
+        "name": "TypedefComplexFields",
+        "kind": 11,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 52,
+                    "character": 8
+                },
+                "end": {
+                    "line": 52,
+                    "character": 28
+                }
+            }
+        },
+        "containerName": ""
+    },
+    {
+        "name": "a",
+        "kind": 8,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 53,
+                    "character": 19
+                },
+                "end": {
+                    "line": 53,
+                    "character": 20
+                }
+            }
+        },
+        "containerName": "TypedefComplexFields"
+    },
+    {
+        "name": "b",
+        "kind": 8,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 54,
+                    "character": 8
+                },
+                "end": {
+                    "line": 54,
+                    "character": 9
+                }
+            }
+        },
+        "containerName": "TypedefComplexFields"
+    }
+]

--- a/cases/documentSymbols/Expected.json
+++ b/cases/documentSymbols/Expected.json
@@ -78,11 +78,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 7,
+                    "line": 12,
                     "character": 13
                 },
                 "end": {
-                    "line": 7,
+                    "line": 12,
                     "character": 16
                 }
             }
@@ -96,11 +96,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 7,
+                    "line": 12,
                     "character": 17
                 },
                 "end": {
-                    "line": 7,
+                    "line": 12,
                     "character": 23
                 }
             }
@@ -114,11 +114,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 7,
+                    "line": 12,
                     "character": 29
                 },
                 "end": {
-                    "line": 7,
+                    "line": 12,
                     "character": 35
                 }
             }
@@ -132,11 +132,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 8,
+                    "line": 18,
                     "character": 17
                 },
                 "end": {
-                    "line": 8,
+                    "line": 18,
                     "character": 21
                 }
             }
@@ -150,11 +150,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 9,
+                    "line": 19,
                     "character": 21
                 },
                 "end": {
-                    "line": 9,
+                    "line": 19,
                     "character": 25
                 }
             }
@@ -168,11 +168,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 10,
+                    "line": 20,
                     "character": 20
                 },
                 "end": {
-                    "line": 10,
+                    "line": 20,
                     "character": 24
                 }
             }
@@ -186,11 +186,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 14,
+                    "line": 24,
                     "character": 24
                 },
                 "end": {
-                    "line": 14,
+                    "line": 24,
                     "character": 27
                 }
             }
@@ -204,11 +204,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 16,
+                    "line": 26,
                     "character": 12
                 },
                 "end": {
-                    "line": 16,
+                    "line": 26,
                     "character": 13
                 }
             }
@@ -222,11 +222,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 18,
+                    "line": 28,
                     "character": 12
                 },
                 "end": {
-                    "line": 18,
+                    "line": 28,
                     "character": 13
                 }
             }
@@ -240,11 +240,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 18,
+                    "line": 28,
                     "character": 15
                 },
                 "end": {
-                    "line": 18,
+                    "line": 28,
                     "character": 16
                 }
             }
@@ -258,11 +258,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 18,
+                    "line": 28,
                     "character": 18
                 },
                 "end": {
-                    "line": 18,
+                    "line": 28,
                     "character": 19
                 }
             }
@@ -276,11 +276,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 21,
+                    "line": 31,
                     "character": 13
                 },
                 "end": {
-                    "line": 21,
+                    "line": 31,
                     "character": 16
                 }
             }
@@ -294,11 +294,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 24,
+                    "line": 34,
                     "character": 10
                 },
                 "end": {
-                    "line": 24,
+                    "line": 34,
                     "character": 19
                 }
             }
@@ -312,11 +312,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 25,
+                    "line": 35,
                     "character": 8
                 },
                 "end": {
-                    "line": 25,
+                    "line": 35,
                     "character": 16
                 }
             }
@@ -330,11 +330,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 26,
+                    "line": 36,
                     "character": 13
                 },
                 "end": {
-                    "line": 26,
+                    "line": 36,
                     "character": 16
                 }
             }
@@ -348,11 +348,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 29,
+                    "line": 39,
                     "character": 9
                 },
                 "end": {
-                    "line": 29,
+                    "line": 39,
                     "character": 17
                 }
             }
@@ -366,11 +366,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 30,
+                    "line": 40,
                     "character": 22
                 },
                 "end": {
-                    "line": 30,
+                    "line": 40,
                     "character": 30
                 }
             }
@@ -384,11 +384,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 32,
+                    "line": 42,
                     "character": 20
                 },
                 "end": {
-                    "line": 32,
+                    "line": 42,
                     "character": 23
                 }
             }
@@ -402,11 +402,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 35,
+                    "line": 45,
                     "character": 16
                 },
                 "end": {
-                    "line": 35,
+                    "line": 45,
                     "character": 28
                 }
             }
@@ -420,11 +420,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 36,
+                    "line": 46,
                     "character": 8
                 },
                 "end": {
-                    "line": 36,
+                    "line": 46,
                     "character": 14
                 }
             }
@@ -438,11 +438,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 37,
+                    "line": 47,
                     "character": 8
                 },
                 "end": {
-                    "line": 37,
+                    "line": 47,
                     "character": 14
                 }
             }
@@ -456,11 +456,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 40,
+                    "line": 50,
                     "character": 5
                 },
                 "end": {
-                    "line": 40,
+                    "line": 50,
                     "character": 9
                 }
             }
@@ -474,11 +474,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 41,
+                    "line": 51,
                     "character": 4
                 },
                 "end": {
-                    "line": 41,
+                    "line": 51,
                     "character": 10
                 }
             }
@@ -492,11 +492,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 42,
+                    "line": 52,
                     "character": 4
                 },
                 "end": {
-                    "line": 42,
+                    "line": 52,
                     "character": 11
                 }
             }
@@ -510,11 +510,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 45,
+                    "line": 55,
                     "character": 8
                 },
                 "end": {
-                    "line": 45,
+                    "line": 55,
                     "character": 17
                 }
             }
@@ -528,11 +528,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 47,
+                    "line": 57,
                     "character": 8
                 },
                 "end": {
-                    "line": 47,
+                    "line": 57,
                     "character": 26
                 }
             }
@@ -546,11 +546,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 48,
+                    "line": 58,
                     "character": 5
                 },
                 "end": {
-                    "line": 48,
+                    "line": 58,
                     "character": 6
                 }
             }
@@ -564,11 +564,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 49,
+                    "line": 59,
                     "character": 4
                 },
                 "end": {
-                    "line": 49,
+                    "line": 59,
                     "character": 5
                 }
             }
@@ -582,11 +582,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 52,
+                    "line": 62,
                     "character": 8
                 },
                 "end": {
-                    "line": 52,
+                    "line": 62,
                     "character": 28
                 }
             }
@@ -600,11 +600,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 53,
+                    "line": 63,
                     "character": 19
                 },
                 "end": {
-                    "line": 53,
+                    "line": 63,
                     "character": 20
                 }
             }
@@ -618,11 +618,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 54,
+                    "line": 64,
                     "character": 8
                 },
                 "end": {
-                    "line": 54,
+                    "line": 64,
                     "character": 9
                 }
             }

--- a/cases/documentSymbols/Expected.json
+++ b/cases/documentSymbols/Expected.json
@@ -270,17 +270,53 @@
         "containerName": "Class.foo"
     },
     {
+        "name": "MacroClass",
+        "kind": 5,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 30,
+                    "character": 20
+                },
+                "end": {
+                    "line": 30,
+                    "character": 30
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
+        "name": "macroField",
+        "kind": 8,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 31,
+                    "character": 16
+                },
+                "end": {
+                    "line": 31,
+                    "character": 26
+                }
+            }
+        },
+        "containerName": "Class.foo.MacroClass"
+    },
+    {
         "name": "maybeIncorrectPos",
         "kind": 13,
         "location": {
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 33,
+                    "line": 37,
                     "character": 16
                 },
                 "end": {
-                    "line": 33,
+                    "line": 37,
                     "character": 33
                 }
             }
@@ -294,11 +330,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 36,
+                    "line": 40,
                     "character": 13
                 },
                 "end": {
-                    "line": 36,
+                    "line": 40,
                     "character": 16
                 }
             }
@@ -312,11 +348,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 39,
+                    "line": 43,
                     "character": 10
                 },
                 "end": {
-                    "line": 39,
+                    "line": 43,
                     "character": 19
                 }
             }
@@ -330,11 +366,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 40,
+                    "line": 44,
                     "character": 8
                 },
                 "end": {
-                    "line": 40,
+                    "line": 44,
                     "character": 16
                 }
             }
@@ -348,11 +384,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 41,
+                    "line": 45,
                     "character": 13
                 },
                 "end": {
-                    "line": 41,
+                    "line": 45,
                     "character": 16
                 }
             }
@@ -366,11 +402,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 44,
+                    "line": 48,
                     "character": 9
                 },
                 "end": {
-                    "line": 44,
+                    "line": 48,
                     "character": 17
                 }
             }
@@ -384,11 +420,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 45,
+                    "line": 49,
                     "character": 22
                 },
                 "end": {
-                    "line": 45,
+                    "line": 49,
                     "character": 30
                 }
             }
@@ -402,11 +438,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 47,
+                    "line": 51,
                     "character": 20
                 },
                 "end": {
-                    "line": 47,
+                    "line": 51,
                     "character": 23
                 }
             }
@@ -420,11 +456,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 50,
+                    "line": 54,
                     "character": 16
                 },
                 "end": {
-                    "line": 50,
+                    "line": 54,
                     "character": 28
                 }
             }
@@ -438,11 +474,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 51,
+                    "line": 55,
                     "character": 8
                 },
                 "end": {
-                    "line": 51,
+                    "line": 55,
                     "character": 14
                 }
             }
@@ -456,11 +492,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 52,
+                    "line": 56,
                     "character": 8
                 },
                 "end": {
-                    "line": 52,
+                    "line": 56,
                     "character": 14
                 }
             }
@@ -474,11 +510,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 55,
+                    "line": 59,
                     "character": 5
                 },
                 "end": {
-                    "line": 55,
+                    "line": 59,
                     "character": 9
                 }
             }
@@ -492,11 +528,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 56,
+                    "line": 60,
                     "character": 4
                 },
                 "end": {
-                    "line": 56,
+                    "line": 60,
                     "character": 10
                 }
             }
@@ -510,11 +546,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 57,
+                    "line": 61,
                     "character": 4
                 },
                 "end": {
-                    "line": 57,
+                    "line": 61,
                     "character": 11
                 }
             }
@@ -528,11 +564,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 60,
+                    "line": 64,
                     "character": 8
                 },
                 "end": {
-                    "line": 60,
+                    "line": 64,
                     "character": 17
                 }
             }
@@ -546,11 +582,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 62,
+                    "line": 66,
                     "character": 8
                 },
                 "end": {
-                    "line": 62,
+                    "line": 66,
                     "character": 26
                 }
             }
@@ -564,11 +600,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 63,
+                    "line": 67,
                     "character": 5
                 },
                 "end": {
-                    "line": 63,
+                    "line": 67,
                     "character": 6
                 }
             }
@@ -582,11 +618,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 64,
+                    "line": 68,
                     "character": 4
                 },
                 "end": {
-                    "line": 64,
+                    "line": 68,
                     "character": 5
                 }
             }
@@ -600,11 +636,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 67,
+                    "line": 71,
                     "character": 8
                 },
                 "end": {
-                    "line": 67,
+                    "line": 71,
                     "character": 28
                 }
             }
@@ -618,11 +654,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 68,
+                    "line": 72,
                     "character": 19
                 },
                 "end": {
-                    "line": 68,
+                    "line": 72,
                     "character": 20
                 }
             }
@@ -636,11 +672,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 69,
+                    "line": 73,
                     "character": 8
                 },
                 "end": {
-                    "line": 69,
+                    "line": 73,
                     "character": 9
                 }
             }

--- a/cases/documentSymbols/Expected.json
+++ b/cases/documentSymbols/Expected.json
@@ -270,17 +270,35 @@
         "containerName": "Class.foo"
     },
     {
+        "name": "maybeIncorrectPos",
+        "kind": 13,
+        "location": {
+            "uri": "file:///cases/documentSymbols/Input.hx",
+            "range": {
+                "start": {
+                    "line": 33,
+                    "character": 16
+                },
+                "end": {
+                    "line": 33,
+                    "character": 33
+                }
+            }
+        },
+        "containerName": "Class.foo"
+    },
+    {
         "name": "new",
         "kind": 9,
         "location": {
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 31,
+                    "line": 36,
                     "character": 13
                 },
                 "end": {
-                    "line": 31,
+                    "line": 36,
                     "character": 16
                 }
             }
@@ -294,11 +312,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 34,
+                    "line": 39,
                     "character": 10
                 },
                 "end": {
-                    "line": 34,
+                    "line": 39,
                     "character": 19
                 }
             }
@@ -312,11 +330,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 35,
+                    "line": 40,
                     "character": 8
                 },
                 "end": {
-                    "line": 35,
+                    "line": 40,
                     "character": 16
                 }
             }
@@ -330,11 +348,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 36,
+                    "line": 41,
                     "character": 13
                 },
                 "end": {
-                    "line": 36,
+                    "line": 41,
                     "character": 16
                 }
             }
@@ -348,11 +366,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 39,
+                    "line": 44,
                     "character": 9
                 },
                 "end": {
-                    "line": 39,
+                    "line": 44,
                     "character": 17
                 }
             }
@@ -366,11 +384,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 40,
+                    "line": 45,
                     "character": 22
                 },
                 "end": {
-                    "line": 40,
+                    "line": 45,
                     "character": 30
                 }
             }
@@ -384,11 +402,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 42,
+                    "line": 47,
                     "character": 20
                 },
                 "end": {
-                    "line": 42,
+                    "line": 47,
                     "character": 23
                 }
             }
@@ -402,11 +420,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 45,
+                    "line": 50,
                     "character": 16
                 },
                 "end": {
-                    "line": 45,
+                    "line": 50,
                     "character": 28
                 }
             }
@@ -420,11 +438,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 46,
+                    "line": 51,
                     "character": 8
                 },
                 "end": {
-                    "line": 46,
+                    "line": 51,
                     "character": 14
                 }
             }
@@ -438,11 +456,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 47,
+                    "line": 52,
                     "character": 8
                 },
                 "end": {
-                    "line": 47,
+                    "line": 52,
                     "character": 14
                 }
             }
@@ -456,11 +474,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 50,
+                    "line": 55,
                     "character": 5
                 },
                 "end": {
-                    "line": 50,
+                    "line": 55,
                     "character": 9
                 }
             }
@@ -474,11 +492,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 51,
+                    "line": 56,
                     "character": 4
                 },
                 "end": {
-                    "line": 51,
+                    "line": 56,
                     "character": 10
                 }
             }
@@ -492,11 +510,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 52,
+                    "line": 57,
                     "character": 4
                 },
                 "end": {
-                    "line": 52,
+                    "line": 57,
                     "character": 11
                 }
             }
@@ -510,11 +528,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 55,
+                    "line": 60,
                     "character": 8
                 },
                 "end": {
-                    "line": 55,
+                    "line": 60,
                     "character": 17
                 }
             }
@@ -528,11 +546,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 57,
+                    "line": 62,
                     "character": 8
                 },
                 "end": {
-                    "line": 57,
+                    "line": 62,
                     "character": 26
                 }
             }
@@ -546,11 +564,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 58,
+                    "line": 63,
                     "character": 5
                 },
                 "end": {
-                    "line": 58,
+                    "line": 63,
                     "character": 6
                 }
             }
@@ -564,11 +582,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 59,
+                    "line": 64,
                     "character": 4
                 },
                 "end": {
-                    "line": 59,
+                    "line": 64,
                     "character": 5
                 }
             }
@@ -582,11 +600,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 62,
+                    "line": 67,
                     "character": 8
                 },
                 "end": {
-                    "line": 62,
+                    "line": 67,
                     "character": 28
                 }
             }
@@ -600,11 +618,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 63,
+                    "line": 68,
                     "character": 19
                 },
                 "end": {
-                    "line": 63,
+                    "line": 68,
                     "character": 20
                 }
             }
@@ -618,11 +636,11 @@
             "uri": "file:///cases/documentSymbols/Input.hx",
             "range": {
                 "start": {
-                    "line": 64,
+                    "line": 69,
                     "character": 8
                 },
                 "end": {
-                    "line": 64,
+                    "line": 69,
                     "character": 9
                 }
             }

--- a/cases/documentSymbols/Input.hx
+++ b/cases/documentSymbols/Input.hx
@@ -28,6 +28,10 @@ class Class {
 
         var a, b, c;
 
+        macro class MacroClass {
+            var macroField:Int;
+        }
+
         // inserted _ name shouldn't appear
         var
         // and also shouldn't affect positions

--- a/cases/documentSymbols/Input.hx
+++ b/cases/documentSymbols/Input.hx
@@ -5,7 +5,17 @@ class Class {
 
     var property(default,null):Int;
 
+    /**
+
+
+
+    **/
     function foo(param1:Int, param2:Int) {
+        "
+
+
+        ";
+
         function foo2() {
             function foo3() {
                 var foo4:Int;

--- a/cases/documentSymbols/Input.hx
+++ b/cases/documentSymbols/Input.hx
@@ -27,6 +27,11 @@ class Class {
         var f = function() {}
 
         var a, b, c;
+
+        // inserted _ name shouldn't appear
+        var
+        // and also shouldn't affect positions
+        var var maybeIncorrectPos:Int;
     }
 
     function new() {}

--- a/cases/documentSymbols/Input.hx
+++ b/cases/documentSymbols/Input.hx
@@ -1,0 +1,56 @@
+class Class {
+    inline static var CONSTANT = 5;
+
+    var variable:Int;
+
+    var property(default,null):Int;
+
+    function foo(param1:Int, param2:Int) {
+        function foo2() {
+            function foo3() {
+                var foo4:Int;
+            }
+        }
+
+        inline function foo() {}
+
+        var f = function() {}
+
+        var a, b, c;
+    }
+
+    function new() {}
+}
+
+interface Interface {
+    var variable:Int;
+    function foo():Void;
+}
+
+abstract Abstract(Int) {
+    inline static var CONSTANT = 5;
+
+    public function new() {}
+}
+
+@:enum abstract EnumAbstract(Int) {
+    var Value1 = 0;
+    var Value2 = 1;
+}
+
+enum Enum {
+    Simple;
+    Complex(i:Int, b:Bool);
+}
+
+typedef TypeAlias = Int;
+
+typedef TypedefShortFields = {
+    ?a:Int,
+    b:Bool
+}
+
+typedef TypedefComplexFields = {
+    @:optional var a:Int;
+    var b:Bool;
+}

--- a/src/haxeLanguageServer/TextDocument.hx
+++ b/src/haxeLanguageServer/TextDocument.hx
@@ -54,6 +54,7 @@ class TextDocument {
                 #end
             }
         }
+        _parsingInfo = null;
         lineOffsets = null;
     }
 

--- a/src/haxeLanguageServer/TextDocument.hx
+++ b/src/haxeLanguageServer/TextDocument.hx
@@ -156,13 +156,16 @@ class TextDocument {
     inline function get_lineCount() return getLineOffsets().length;
 
     function createParsingInfo() {
-        return switch (hxParser.HxParser.parse(content)) {
+        return try switch (hxParser.HxParser.parse(content)) {
             case Success(tree):
                 var tree = new hxParser.Converter(tree).convertResultToFile();
                 var manager = new ParsingPointManager();
                 manager.walkFile(tree, Root);
                 { tree:tree, parsingPointManager:manager };
             case Failure(_): null;
+        } catch (e:Any) {
+            trace('hxparser failed to parse $uri with: \'$e\'');
+            null;
         }
     }
 

--- a/src/haxeLanguageServer/TextDocument.hx
+++ b/src/haxeLanguageServer/TextDocument.hx
@@ -19,10 +19,8 @@ class TextDocument {
     public var content(default,null):String;
     public var openTimestamp(default,null):Float;
     public var lineCount(get,never):Int;
-    #if false
     public var parsingInfo(get,never):DocumentParsingInformation;
     var _parsingInfo:Null<DocumentParsingInformation>;
-    #end
     @:allow(haxeLanguageServer.TextDocuments)
     var lineOffsets:Array<Int>;
     var onUpdateListeners:Array<OnTextDocumentChangeListener> = [];
@@ -157,8 +155,6 @@ class TextDocument {
 
     inline function get_lineCount() return getLineOffsets().length;
 
-    #if false
-
     function createParsingInfo() {
         return switch (hxParser.HxParser.parse(content)) {
             case Success(tree):
@@ -177,6 +173,7 @@ class TextDocument {
         return _parsingInfo;
     }
 
+    #if false
     function updateParsingInfo(range:Range, rangeLength:Int, textLength:Int) {
         if (_parsingInfo == null) {
             _parsingInfo = createParsingInfo();

--- a/src/haxeLanguageServer/TextDocument.hx
+++ b/src/haxeLanguageServer/TextDocument.hx
@@ -152,10 +152,13 @@ class TextDocument {
 
     function createParseTree() {
         return try switch (hxParser.HxParser.parse(content)) {
-            case Success(tree): new hxParser.Converter(tree).convertResultToFile();
-            case Failure(_): null;
+            case Success(tree):
+                new hxParser.Converter(tree).convertResultToFile();
+            case Failure(error):
+                trace('hxparser failed to parse $uri with: \'$error\'');
+                null;
         } catch (e:Any) {
-            trace('hxparser failed to parse $uri with: \'$e\'');
+            trace('hxParser.Converter failed on $uri with: \'$e\'');
             null;
         }
     }

--- a/src/haxeLanguageServer/TextDocument.hx
+++ b/src/haxeLanguageServer/TextDocument.hx
@@ -2,7 +2,6 @@ package haxeLanguageServer;
 
 import haxe.Timer;
 import hxParser.ParseTree;
-import js.node.Buffer;
 
 typedef OnTextDocumentChangeListener = TextDocument->Array<TextDocumentContentChangeEvent>->Int->Void;
 

--- a/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
+++ b/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
@@ -80,9 +80,10 @@ class DocumentSymbolsFeature {
         var resolver = new DocumentSymbolsResolver(doc.uri);
         try if (doc.parseTree != null) {
             resolver.walkFile(doc.parseTree, Root);
-            return resolve(resolver.results);
+            return resolve(resolver.getSymbols());
         } catch (e:Any) {
             trace('DocumentSymbolsResolver failed with \'$e\'');
+            trace(haxe.CallStack.toString(haxe.CallStack.callStack()));
         }
 
         trace('Falling back to Haxe document symbols.');

--- a/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
+++ b/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
@@ -78,8 +78,8 @@ class DocumentSymbolsFeature {
     function onDocumentSymbols(params:DocumentSymbolParams, token:CancellationToken, resolve:Array<SymbolInformation>->Void, reject:ResponseError<NoData>->Void) {
         var doc = context.documents.get(params.textDocument.uri);
         var resolver = new DocumentSymbolsResolver(doc.uri);
-        try if (doc.parsingInfo != null) {
-            resolver.walkFile(doc.parsingInfo.tree, Root);
+        try if (doc.parseTree != null) {
+            resolver.walkFile(doc.parseTree, Root);
             return resolve(resolver.results);
         } catch (e:Any) {
             trace('DocumentSymbolsResolver failed with \'$e\'');

--- a/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
+++ b/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
@@ -3,6 +3,7 @@ package haxeLanguageServer.features;
 import jsonrpc.CancellationToken;
 import jsonrpc.ResponseError;
 import jsonrpc.Types.NoData;
+import haxeLanguageServer.hxParser.DocumentSymbolsResolver;
 
 @:enum
 private abstract ModuleSymbolKind(Int) {
@@ -76,6 +77,10 @@ class DocumentSymbolsFeature {
 
     function onDocumentSymbols(params:DocumentSymbolParams, token:CancellationToken, resolve:Array<SymbolInformation>->Void, reject:ResponseError<NoData>->Void) {
         var doc = context.documents.get(params.textDocument.uri);
+        var resolver = new DocumentSymbolsResolver(doc.uri);
+        resolver.walkFile(doc.parsingInfo.tree, Root);
+        return resolve(resolver.results);
+
         var args = ["--display", '${doc.fsPath}@0@module-symbols'];
         makeRequest(args, doc, token, resolve, reject);
     }

--- a/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
+++ b/src/haxeLanguageServer/features/DocumentSymbolsFeature.hx
@@ -78,9 +78,14 @@ class DocumentSymbolsFeature {
     function onDocumentSymbols(params:DocumentSymbolParams, token:CancellationToken, resolve:Array<SymbolInformation>->Void, reject:ResponseError<NoData>->Void) {
         var doc = context.documents.get(params.textDocument.uri);
         var resolver = new DocumentSymbolsResolver(doc.uri);
-        resolver.walkFile(doc.parsingInfo.tree, Root);
-        return resolve(resolver.results);
+        try if (doc.parsingInfo != null) {
+            resolver.walkFile(doc.parsingInfo.tree, Root);
+            return resolve(resolver.results);
+        } catch (e:Any) {
+            trace('DocumentSymbolsResolver failed with \'$e\'');
+        }
 
+        trace('Falling back to Haxe document symbols.');
         var args = ["--display", '${doc.fsPath}@0@module-symbols'];
         makeRequest(args, doc, token, resolve, reject);
     }

--- a/src/haxeLanguageServer/helper/StringHelper.hx
+++ b/src/haxeLanguageServer/helper/StringHelper.hx
@@ -1,0 +1,7 @@
+package haxeLanguageServer.helper;
+
+class StringHelper {
+    public static inline function occurrences(s:String, of:String) {
+        return s.length - s.replace(of, "").length;
+    }
+}

--- a/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
@@ -139,7 +139,7 @@ class DocumentSymbolsResolver extends StackAwareWalker {
     }
 
     override function walkFunction(node:Function, stack:WalkStack) {
-        addSymbol(node.name, SymbolKind.Function, stack);
+        if (node.name != null) addSymbol(node.name, SymbolKind.Function, stack);
         super.walkFunction(node, stack);
     }
 
@@ -151,5 +151,10 @@ class DocumentSymbolsResolver extends StackAwareWalker {
     override function walkNEnumField(node:NEnumField, stack:WalkStack) {
         addSymbol(node.name, SymbolKind.Function, stack);
         super.walkNEnumField(node, stack);
+    }
+
+    override function walkAnonymousStructureField(node:AnonymousStructureField, stack:WalkStack) {
+        addSymbol(node.name, SymbolKind.Variable, stack);
+        super.walkAnonymousStructureField(node, stack);
     }
 }

--- a/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
@@ -92,6 +92,16 @@ class DocumentSymbolsResolver extends StackAwareWalker {
         super.walkClassField_Property(annotations, modifiers, varKeyword, name, parenOpen, read, comma, write, parenClose, typeHint, assignment, semicolon, stack);
     }
 
+    override function walkVarDecl(node:VarDecl, stack:WalkStack) {
+        tokenMap[node.name] = SymbolKind.Variable;
+        super.walkVarDecl(node, stack);
+    }
+
+    override function walkBlockElement_InlineFunction(inlineKeyword:Token, functionKeyword:Token, fun:Function, semicolon:Token, stack:WalkStack) {
+        if (fun.name != null) tokenMap[fun.name] = SymbolKind.Function;
+        super.walkBlockElement_InlineFunction(inlineKeyword, functionKeyword, fun, semicolon, stack);
+    }
+
     override function walkExpr_EVar(varKeyword:Token, decl:VarDecl, stack:WalkStack) {
         tokenMap[decl.name] = SymbolKind.Variable;
         super.walkExpr_EVar(varKeyword, decl, stack);

--- a/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
@@ -20,8 +20,12 @@ class DocumentSymbolsResolver extends StackAwareWalker {
     }
 
     override function walkToken(token:Token, stack:WalkStack) {
-        updatePosition(token.leadingTrivia);
+        processTrivia(token.leadingTrivia);
+        if (token.appearsInSource()) processToken(token);
+        processTrivia(token.trailingTrivia);
+    }
 
+    function processToken(token:Token) {
         if (symbols[token] != null) {
             symbols[token].location = {
                 uri: uri,
@@ -33,10 +37,9 @@ class DocumentSymbolsResolver extends StackAwareWalker {
         }
 
         character += token.text.length;
-        updatePosition(token.trailingTrivia);
     }
 
-    function updatePosition(trivias:Array<Trivia>) {
+    function processTrivia(trivias:Array<Trivia>) {
         for (trivia in trivias) {
             var newlines = trivia.text.occurrences("\n");
             if (newlines > 0) {

--- a/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
@@ -1,0 +1,104 @@
+package haxeLanguageServer.hxParser;
+
+import hxParser.ParseTree;
+import hxParser.StackAwareWalker;
+import hxParser.WalkStack;
+using Lambda;
+
+class DocumentSymbolsResolver extends StackAwareWalker {
+    var uri:DocumentUri;
+    var line:Int = 0;
+    var character:Int = 0;
+    var tokenMap:Map<Token, SymbolKind> = new Map();
+
+    public var results(default, null):Array<SymbolInformation> = [];
+
+    public function new(uri:DocumentUri) {
+        this.uri = uri;
+    }
+
+    override function walkToken(token:Token, stack:WalkStack) {
+        updatePosition(token.leadingTrivia);
+
+        if (tokenMap[token] != null) {
+            results.push({
+                name: token.text,
+                kind: tokenMap[token],
+                location: {
+                    uri: uri,
+                    range: {
+                        start: {line: line, character: character},
+                        end: {line: line, character: character + token.text.length}
+                    }
+                }
+            });
+            tokenMap[token] = null;
+        }
+
+        character += token.text.length;
+        updatePosition(token.trailingTrivia);
+    }
+
+    function updatePosition(trivias:Array<Trivia>) {
+        for (trivia in trivias) {
+            var newlines = trivia.text.occurrences("\n");
+            if (newlines > 0) {
+                line += newlines;
+                character = 0;
+            } else {
+                character += trivia.text.length;
+            }
+        }
+    }
+
+    override function walkTypedefDecl(node:TypedefDecl, stack:WalkStack) {
+        tokenMap[node.name] = SymbolKind.Interface;
+        super.walkTypedefDecl(node, stack);
+    }
+
+    override function walkClassDecl(node:ClassDecl, stack:WalkStack) {
+        tokenMap[node.name] = if (node.kind.text == "interface") SymbolKind.Interface else SymbolKind.Class;
+        super.walkClassDecl(node, stack);
+    }
+
+    override function walkEnumDecl(node:EnumDecl, stack:WalkStack) {
+        tokenMap[node.name] = SymbolKind.Enum;
+        super.walkEnumDecl(node, stack);
+    }
+
+    override function walkAbstractDecl(node:AbstractDecl, stack:WalkStack) {
+        tokenMap[node.name] = SymbolKind.Class;
+        super.walkAbstractDecl(node, stack);
+    }
+
+    override function walkClassField_Function(annotations:NAnnotations, modifiers:Array<FieldModifier>, functionKeyword:Token, name:Token, params:Null<TypeDeclParameters>, parenOpen:Token, args:Null<CommaSeparated<FunctionArgument>>, parenClose:Token, typeHint:Null<TypeHint>, expr:MethodExpr, stack:WalkStack) {
+        tokenMap[name] = if (name.text == "new") SymbolKind.Constructor else SymbolKind.Function;
+        super.walkClassField_Function(annotations, modifiers, functionKeyword, name, params, parenOpen, args, parenClose, typeHint, expr, stack);
+    }
+
+    override function walkFunctionArgument(node:FunctionArgument, stack:WalkStack) {
+        tokenMap[node.name] = SymbolKind.Variable;
+        super.walkFunctionArgument(node, stack);
+    }
+
+    override function walkClassField_Variable(annotations:NAnnotations, modifiers:Array<FieldModifier>, varKeyword:Token, name:Token, typeHint:Null<TypeHint>, assignment:Null<Assignment>, semicolon:Token, stack:WalkStack) {
+        var isInline = modifiers.exists(function(modifier) return modifier.match(FieldModifier.Inline(_)));
+        tokenMap[name] = if (isInline) SymbolKind.Constant else SymbolKind.Field;
+        super.walkClassField_Variable(annotations, modifiers, varKeyword, name, typeHint, assignment, semicolon, stack);
+    }
+
+    override function walkClassField_Property(annotations:NAnnotations, modifiers:Array<FieldModifier>, varKeyword:Token, name:Token, parenOpen:Token, read:Token, comma:Token, write:Token, parenClose:Token, typeHint:Null<TypeHint>, assignment:Null<Assignment>, semicolon:Token, stack:WalkStack) {
+        tokenMap[name] = SymbolKind.Property;
+        super.walkClassField_Property(annotations, modifiers, varKeyword, name, parenOpen, read, comma, write, parenClose, typeHint, assignment, semicolon, stack);
+    }
+
+    override function walkExpr_EVar(varKeyword:Token, decl:VarDecl, stack:WalkStack) {
+        tokenMap[decl.name] = SymbolKind.Variable;
+        super.walkExpr_EVar(varKeyword, decl, stack);
+    }
+
+    override function walkExpr_EFunction(functionKeyword:Token, fun:Function, stack:WalkStack) {
+        if (fun.name != null) tokenMap[fun.name] = SymbolKind.Function;
+        super.walkExpr_EFunction(functionKeyword, fun, stack);
+    }
+}

--- a/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
@@ -147,4 +147,9 @@ class DocumentSymbolsResolver extends StackAwareWalker {
         addSymbol(decl.name, SymbolKind.Variable, stack);
         super.walkExpr_EVar(varKeyword, decl, stack);
     }
+
+    override function walkNEnumField(node:NEnumField, stack:WalkStack) {
+        addSymbol(node.name, SymbolKind.Function, stack);
+        super.walkNEnumField(node, stack);
+    }
 }

--- a/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
@@ -68,7 +68,7 @@ class DocumentSymbolsResolver extends StackAwareWalker {
                         case EnumDecl(decl): add(decl.name);
                         case TypedefDecl(decl): add(decl.name);
                         case Function(node): add(node.name);
-                        case ClassField_Function(_,_,_, name, _,_,_,_,_,_):
+                        case ClassField_Function(_, _, _, name, _, _, _, _, _, _):
                             add(name);
                         case _:
                     };
@@ -139,7 +139,7 @@ class DocumentSymbolsResolver extends StackAwareWalker {
     }
 
     override function walkFunction(node:Function, stack:WalkStack) {
-        addSymbol(node.name,  SymbolKind.Function, stack);
+        addSymbol(node.name, SymbolKind.Function, stack);
         super.walkFunction(node, stack);
     }
 

--- a/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
+++ b/src/haxeLanguageServer/hxParser/DocumentSymbolsResolver.hx
@@ -157,4 +157,12 @@ class DocumentSymbolsResolver extends StackAwareWalker {
         addSymbol(node.name, SymbolKind.Variable, stack);
         super.walkAnonymousStructureField(node, stack);
     }
+
+    override function walkLiteral_PLiteralString(s:StringToken, stack:WalkStack) {
+        var string = switch (s) {
+            case DoubleQuote(token) | SingleQuote(token): token.text;
+        }
+        line += string.occurrences("\n");
+        super.walkLiteral_PLiteralString(s, stack);
+    }
 }

--- a/src/haxeLanguageServer/import.hx
+++ b/src/haxeLanguageServer/import.hx
@@ -6,4 +6,5 @@ using StringTools;
 using haxeLanguageServer.helper.RangeHelper;
 using haxeLanguageServer.helper.PositionHelper;
 using haxeLanguageServer.helper.ArrayHelper;
+using haxeLanguageServer.helper.StringHelper;
 using haxeLanguageServer.helper.DocumentUriHelper;

--- a/test/TestMain.hx
+++ b/test/TestMain.hx
@@ -8,6 +8,7 @@ class TestMain {
 
         CompileTime.importPackage("haxeLanguageServer.helper");
         CompileTime.importPackage("haxeLanguageServer.features");
+        CompileTime.importPackage("haxeLanguageServer.hxParser");
 
         var tests = CompileTime.getAllClasses(TestCaseBase);
         for (testClass in tests) runner.add(Type.createInstance(testClass, []));

--- a/test/haxeLanguageServer/hxParser/DocumentSymbolsResolverTest.hx
+++ b/test/haxeLanguageServer/hxParser/DocumentSymbolsResolverTest.hx
@@ -1,0 +1,25 @@
+package haxeLanguageServer.hxParser;
+
+import haxe.Json;
+import haxeLanguageServer.TextDocument;
+
+class DocumentSymbolsResolverTest extends TestCaseBase {
+    function test() {
+        var basePath = "cases/documentSymbols";
+        var inputPath = '$basePath/Input.hx';
+
+        var content = sys.io.File.getContent(inputPath);
+        var uri = new FsPath(inputPath).toUri();
+        var document = new TextDocument(uri, "haxe", 0, content);
+        var resolver = new DocumentSymbolsResolver(uri);
+        resolver.walkFile(document.parseTree, Root);
+
+        var stringify = Json.stringify.bind(_, null, "    ");
+        var actual = stringify(resolver.getSymbols());
+        sys.io.File.saveContent('$basePath/Actual.json', actual);
+        var expected = stringify(Json.parse(sys.io.File.getContent('$basePath/Expected.json')));
+
+        // use "Compare Active File With..." and select Actual.json and Expected.json for debugging
+        assertTrue(actual == expected);
+    }
+}


### PR DESCRIPTION
Should be much more robust and work basically everywhere, even with not totally valid Haxe code or without a display config (so no more issues like https://github.com/HaxeFoundation/haxe/issues/6107).

The old method is used as a fallback in case it fails.