### PR TITLE
Handle exit()

### DIFF
--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -3,6 +3,7 @@ package haxeLanguageServer;
 import haxe.Timer;
 import haxe.Json;
 import haxe.extern.EitherType;
+import js.Node.process;
 import jsonrpc.CancellationToken;
 import jsonrpc.ResponseError;
 import jsonrpc.Types;
@@ -74,6 +75,7 @@ class Context {
 
         protocol.onRequest(Methods.Initialize, onInitialize);
         protocol.onRequest(Methods.Shutdown, onShutdown);
+        protocol.onNotification(Methods.Exit, onExit);
         protocol.onNotification(Methods.DidChangeConfiguration, onDidChangeConfiguration);
         protocol.onNotification(Methods.DidOpenTextDocument, onDidOpenTextDocument);
         protocol.onNotification(Methods.DidSaveTextDocument, onDidSaveTextDocument);
@@ -159,6 +161,16 @@ class Context {
         haxeServer.stop();
         haxeServer = null;
         return resolve(null);
+    }
+
+    function onExit(_) {
+        if (haxeServer != null) {
+            haxeServer.stop();
+            haxeServer = null;
+            process.exit(1);
+        } else {
+            process.exit(0);
+        }
     }
 
     function onDidChangeConfiguration(newConfig:DidChangeConfigurationParams) {


### PR DESCRIPTION
Using haxe LSP with neovim, I noticed the haxe language server was still alive and processes were piling up eating my RAM. I think I had the issue with vscode too.

Haxe LSP simply was not handling the `exit()` notification.