### PR TITLE
Update hxml define to haxe5preview1

### DIFF
--- a/src/haxeLanguageServer/features/hxml/data/Defines.hx
+++ b/src/haxeLanguageServer/features/hxml/data/Defines.hx
@@ -77,6 +77,10 @@ private typedef DefineData = {
 	final ?links:ReadOnlyArray<String>;
 	final ?reserved:Bool;
 	final ?origin:String;
+	final ?defaultValue:String;
+	final ?signatureNeutral:Bool;
+	final ?deprecated:String;
+	final ?deprecatedDefine:String;
 }
 
 typedef VersionInfo = {
@@ -89,12 +93,16 @@ private final DefineVersions:Map<String, VersionInfo> = {
 	final v4_0_0_rc4 = new SemVer(4, 0, 0, "rc.4");
 	final v4_1_0 = new SemVer(4, 1, 0);
 	final v4_2_0 = new SemVer(4, 2, 0);
+	final v4_last = new SemVer(4, 3, 7);
+	final v5_0_0_preview1 = new SemVer(5, 0, 0, "preview.1");
 	[
 		"CsVer" => {
-			since: v4_0_0_rc3
+			since: v4_0_0_rc3,
+			until: v4_last
 		},
 		"NetcoreVer" => {
-			since: v4_0_0_rc3
+			since: v4_0_0_rc3,
+			until: v4_last
 		},
 		"DumpPath" => {
 			since: v4_0_0_rc4
@@ -109,7 +117,8 @@ private final DefineVersions:Map<String, VersionInfo> = {
 			since: v4_1_0
 		},
 		"JarLegacyLoader" => {
-			since: v4_2_0
+			since: v4_2_0,
+			until: v4_last
 		},
 		"NoCOpt" => {
 			until: v4_1_0
@@ -122,7 +131,181 @@ private final DefineVersions:Map<String, VersionInfo> = {
 		},
 		"JvmDynamicLevel" => {
 			since: v4_2_0
-		}
+		},
+		"CoreApiSerialize" => {
+			until: v4_last
+		},
+		"DllImport" => {
+			until: v4_last
+		},
+		"EraseGenerics" => {
+			until: v4_last
+		},
+		"FastCast" => {
+			until: v4_last
+		},
+		"ForceLibCheck" => {
+			until: v4_last
+		},
+		"GencommonDebug" => {
+			until: v4_last
+		},
+		"JavaVer" => {
+			until: v4_last
+		},
+		"Jvm" => {
+			until: v4_last
+		},
+		"KeepOldOutput" => {
+			until: v4_last
+		},
+		"NetVer" => {
+			until: v4_last
+		},
+		"NetTarget" => {
+			until: v4_last
+		},
+		"NoRoot" => {
+			until: v4_last
+		},
+		"ReplaceFiles" => {
+			until: v4_last
+		},
+		"Unsafe" => {
+			until: v4_last
+		},
+		"AnalyzerTimes" => {
+			since: v5_0_0_preview1
+		},
+		"DisableHxbCache" => {
+			since: v5_0_0_preview1
+		},
+		"DisableHxbOptimizations" => {
+			since: v5_0_0_preview1
+		},
+		"EnableParallelism" => {
+			since: v5_0_0_preview1
+		},
+		"DumpStage" => {
+			since: v5_0_0_preview1
+		},
+		"EvalPrintDepth" => {
+			since: v5_0_0_preview1
+		},
+		"EvalPrettyPrint" => {
+			since: v5_0_0_preview1
+		},
+		"FailFast" => {
+			since: v5_0_0_preview1
+		},
+		"Haxe3" => {
+			since: v5_0_0_preview1
+		},
+		"Haxe4" => {
+			since: v5_0_0_preview1
+		},
+		"Haxe5" => {
+			since: v5_0_0_preview1
+		},
+		"HaxeNext" => {
+			since: v5_0_0_preview1
+		},
+		"HaxeOutputFile" => {
+			since: v5_0_0_preview1
+		},
+		"HaxeOutputPart" => {
+			since: v5_0_0_preview1
+		},
+		"Hlc" => {
+			since: v5_0_0_preview1
+		},
+		"HxbTimes" => {
+			since: v5_0_0_preview1
+		},
+		"HxbStats" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppGcMoving" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppGcSummary" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppGcDynamicSize" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppGcBigBlocks" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppGcDebugLevel" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppDebugLink" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppStackTrace" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppStackLine" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppCheckPointer" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppProfiler" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppTelemetry" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppCpp11" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppVerbose" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppTimes" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppM32" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppM64" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppArm64" => {
+			since: v5_0_0_preview1
+		},
+		"HxcppLinuxArm64" => {
+			since: v5_0_0_preview1
+		},
+		"JsGlobal" => {
+			since: v5_0_0_preview1
+		},
+		"NekoNoHaxelibPaths" => {
+			since: v5_0_0_preview1
+		},
+		"RetainUntypedMeta" => {
+			since: v5_0_0_preview1
+		},
+		"SwfHeader" => {
+			since: v5_0_0_preview1
+		},
+		"MessageReporting" => {
+			since: v5_0_0_preview1
+		},
+		"MessageColor" => {
+			since: v5_0_0_preview1
+		},
+		"MessageAbsolutePositions" => {
+			since: v5_0_0_preview1
+		},
+		"MessageLogFile" => {
+			since: v5_0_0_preview1
+		},
+		"MessageLogFormat" => {
+			since: v5_0_0_preview1
+		},
 	];
 }
 
@@ -133,7 +316,7 @@ private function integers(from:Int, to:Int):EnumValues {
 private final DefineEnums:Map<String, EnumValues> = [
 	"Dce" => DceEnumValues,
 	"Dump" => [{name: "pretty"}, {name: "record"}, {name: "position"}, {name: "legacy"}],
-	"HlVer" => [{name: "1.10.0"}, {name: "1.11.0"}, {name: "1.12.0"}],
+	"HlVer" => [for (i in 10...16) {name: "1." + Std.string(i) + ".0"}],
 	"JavaVer" => [{name: "7"}, {name: "6"}, {name: "5"}],
 	"JsEs" => [{name: "6"}, {name: "5"}, {name: "3"}],
 	"LuaVer" => [{name: "5.2"}, {name: "5.1"}],
@@ -150,7 +333,17 @@ private final DefineEnums:Map<String, EnumValues> = [
 		{name: "1", description: "field read/write optimization (default)"},
 		{name: "0", description: "none"},
 		{name: "2", description: "compile-time method closures"},
-	]
+	],
+	"AnalyzerTimes" => integers(0, 2),
+	"DumpStage" => [
+		{name: "typing"},
+		{name: "casting"},
+		{name: "inlining"},
+		{name: "analyzing"},
+		{name: "dce"}
+	],
+	"MessageReporting" => [{name: "classic"}, {name: "pretty"}, {name: "indent"}],
+	"MessageLogFormat" => [{name: "classic"}, {name: "pretty"}, {name: "indent"}],
 ];
 
 function getDefines(includeReserved:Bool):ReadOnlyArray<Define> {
@@ -169,53 +362,11 @@ private final RemovedDefines:ReadOnlyArray<DefineData> = [
 		"define": "old-constructor-inline",
 		"doc": "Use old constructor inlining logic (from Haxe 3.4.2) instead of the reworked version."
 	},
-];
-
-// from https://github.com/HaxeFoundation/haxe/blob/development/src-json/define.json
-
-private final Defines:ReadOnlyArray<DefineData> = [
-	{
-		"name": "AbsolutePath",
-		"define": "absolute_path",
-		"doc": "Print absolute file path in trace output."
-	},
-	{
-		"name": "AdvancedTelemetry",
-		"define": "advanced-telemetry",
-		"doc": "Allow the SWF to be measured with Monocle tool.",
-		"platforms": ["flash"]
-	},
-	{
-		"name": "AnalyzerOptimize",
-		"define": "analyzer_optimize",
-		"doc": "Perform advanced optimizations."
-	},
-	{
-		"name": "AnnotateSource",
-		"define": "annotate_source",
-		"doc": "Add additional comments to generated source code.",
-		"platforms": ["cpp"]
-	},
-	{
-		"name": "CheckXmlProxy",
-		"define": "check_xml_proxy",
-		"doc": "Check the used fields of the XML proxy."
-	},
-	{
-		"name": "CoreApi",
-		"define": "core_api",
-		"doc": "Defined in the core API context."
-	},
 	{
 		"name": "CoreApiSerialize",
 		"define": "core_api_serialize",
 		"doc": "Mark some generated core API classes with the `Serializable` attribute on C#.",
 		"platforms": ["cs"]
-	},
-	{
-		"name": "Cppia",
-		"define": "cppia",
-		"doc": "Generate cpp instruction assembly."
 	},
 	{
 		"name": "CsVer",
@@ -225,89 +376,10 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"params": ["version"]
 	},
 	{
-		"name": "NoCppiaAst",
-		"define": "nocppiaast",
-		"doc": "Use legacy cppia generation."
-	},
-	{
-		"name": "Dce",
-		"define": "dce",
-		"doc": "Set the dead code elimination mode. (default: std)",
-		"params": ["mode: std | full | no"],
-		"links": ["https://haxe.org/manual/cr-dce.html"]
-	},
-	{
-		"name": "DceDebug",
-		"define": "dce_debug",
-		"doc": "Show DCE log.",
-		"links": ["https://haxe.org/manual/cr-dce.html"]
-	},
-	{
-		"name": "Debug",
-		"define": "debug",
-		"doc": "Activated when compiling with -debug."
-	},
-	{
-		"name": "DisableUnicodeStrings",
-		"define": "disable_unicode_strings",
-		"doc": "Disable Unicode support in `String` type.",
-		"platforms": ["cpp"]
-	},
-	{
-		"name": "Display",
-		"define": "display",
-		"doc": "Activated during completion.",
-		"links": ["https://haxe.org/manual/cr-completion.html"]
-	},
-	{
-		"name": "DisplayStdin",
-		"define": "display_stdin",
-		"doc": "Read the contents of a file specified in `--display` from standard input."
-	},
-	{
-		"name": "DllExport",
-		"define": "dll_export",
-		"doc": "GenCPP experimental linking.",
-		"platforms": ["cpp"]
-	},
-	{
 		"name": "DllImport",
 		"define": "dll_import",
 		"doc": "Handle Haxe-generated .NET DLL imports.",
 		"platforms": ["cs"]
-	},
-	{
-		"name": "DocGen",
-		"define": "doc_gen",
-		"doc": "Do not perform any removal/change in order to correctly generate documentation."
-	},
-	{
-		"name": "Dump",
-		"define": "dump",
-		"doc": "Dump typed AST in dump subdirectory using specified mode or non-prettified default.",
-		"params": ["mode: pretty | record | position | legacy"]
-	},
-	{
-		"name": "DumpPath",
-		"define": "dump_path",
-		"doc": "Path to generate dumps to (default: \"dump\").",
-		"params": ["path"]
-	},
-	{
-		"name": "DumpDependencies",
-		"define": "dump_dependencies",
-		"doc": "Dump the classes dependencies in a dump subdirectory."
-	},
-	{
-		"name": "DumpIgnoreVarIds",
-		"define": "dump_ignore_var_ids",
-		"doc": "Remove variable IDs from non-pretty dumps (helps with diff)."
-	},
-	{
-		"name": "DynamicInterfaceClosures",
-		"define": "dynamic_interface_closures",
-		"doc": "Use slow path for interface closures to save space.",
-		"platforms": ["cpp"]
 	},
 	{
 		"name": "EraseGenerics",
@@ -316,64 +388,10 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"platforms": ["cs"]
 	},
 	{
-		"name": "EvalCallStackDepth",
-		"define": "eval_call_stack_depth",
-		"doc": "Set maximum call stack depth for eval. (default: 1000)",
-		"platforms": ["eval"],
-		"params": ["depth"]
-	},
-	{
-		"name": "EvalDebugger",
-		"define": "eval_debugger",
-		"doc": "Support debugger in macro/interp mode. Allows `host:port` value to open a socket. Implies eval_stack.",
-		"platforms": ["eval"]
-	},
-	{
-		"name": "EvalStack",
-		"define": "eval_stack",
-		"doc": "Record stack information in macro/interp mode.",
-		"platforms": ["eval"]
-	},
-	{
-		"name": "EvalTimes",
-		"define": "eval_times",
-		"doc": "Record per-method execution times in macro/interp mode. Implies eval_stack.",
-		"platforms": ["eval"]
-	},
-	{
-		"name": "FilterTimes",
-		"define": "filter_times",
-		"doc": "Record per-filter execution times upon --times."
-	},
-	{
 		"name": "FastCast",
 		"define": "fast_cast",
 		"doc": "Enables an experimental casts cleanup on C# and Java.",
 		"platforms": ["cs", "java"]
-	},
-	{
-		"name": "Fdb",
-		"define": "fdb",
-		"doc": "Enable full flash debug infos for FDB interactive debugging.",
-		"platforms": ["flash"]
-	},
-	{
-		"name": "FileExtension",
-		"define": "file_extension",
-		"doc": "Output filename extension for cpp source code.",
-		"platforms": ["cpp"]
-	},
-	{
-		"name": "FlashStrict",
-		"define": "flash_strict",
-		"doc": "More strict typing for flash target.",
-		"platforms": ["flash"]
-	},
-	{
-		"name": "FlashUseStage",
-		"define": "flash_use_stage",
-		"doc": "Keep the SWF library initial stage.",
-		"platforms": ["flash"]
 	},
 	{
 		"devcomment": "force_lib_check is only here as a debug facility - compiler checking allows errors to be found more easily",
@@ -383,82 +401,10 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"platforms": ["cs", "java"]
 	},
 	{
-		"name": "ForceNativeProperty",
-		"define": "force_native_property",
-		"doc": "Tag all properties with `:nativeProperty` metadata for 3.1 compatibility.",
-		"platforms": ["cpp"]
-	},
-	{
 		"name": "GencommonDebug",
 		"define": "gencommon_debug",
 		"doc": "GenCommon internal.",
 		"platforms": ["cs", "java"]
-	},
-	{
-		"name": "Haxe3Compat",
-		"define": "haxe3compat",
-		"doc": "Gives warnings about transition from Haxe 3.x to Haxe 4.0."
-	},
-	{
-		"name": "HaxeBoot",
-		"define": "haxe_boot",
-		"doc": "Give the name 'haxe' to the flash boot class instead of a generated name.",
-		"platforms": ["flash"]
-	},
-	{
-		"name": "HaxeVer",
-		"define": "haxe_ver",
-		"doc": "The current Haxe version value as decimal number. E.g. 3.407 for 3.4.7.",
-		"reserved": true
-	},
-	{
-		"name": "Haxe",
-		"define": "haxe",
-		"doc": "The current Haxe version value in SemVer format.",
-		"reserved": true
-	},
-	{
-		"name": "HlVer",
-		"define": "hl_ver",
-		"doc": "The HashLink version to target. (default: 1.10.0)",
-		"platforms": ["hl"],
-		"params": ["version"]
-	},
-	{
-		"name": "HxcppApiLevel",
-		"define": "hxcpp_api_level",
-		"doc": "Provided to allow compatibility between hxcpp versions.",
-		"platforms": ["cpp"],
-		"reserved": true
-	},
-	{
-		"name": "HxcppGcGenerational",
-		"define": "HXCPP_GC_GENERATIONAL",
-		"doc": "Experimental Garbage Collector.",
-		"platforms": ["cpp"]
-	},
-	{
-		"name": "HxcppDebugger",
-		"define": "HXCPP_DEBUGGER",
-		"doc": "Include additional information for hxcpp_debugger.",
-		"platforms": ["cpp"]
-	},
-	{
-		"name": "HxcppSmartStings",
-		"define": "hxcpp_smart_strings",
-		"doc": "Use wide strings in hxcpp. (Turned on by default unless `-D disable_unicode_strings` is specified.)",
-		"platforms": ["cpp"]
-	},
-	{
-		"name": "IncludePrefix",
-		"define": "include_prefix",
-		"doc": "Prepend path to generated include files.",
-		"platforms": ["cpp"]
-	},
-	{
-		"name": "Interp",
-		"define": "interp",
-		"doc": "The code is compiled to be run with `--interp`."
 	},
 	{
 		"name": "JarLegacyLoader",
@@ -474,59 +420,9 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"params": ["version: 5-7"]
 	},
 	{
-		"name": "JsClassic",
-		"define": "js_classic",
-		"doc": "Don't use a function wrapper and strict mode in JS output.",
-		"platforms": ["js"]
-	},
-	{
-		"name": "JsEs",
-		"define": "js_es",
-		"doc": "Generate JS compliant with given ES standard version. (default: 5)",
-		"platforms": ["js"],
-		"params": ["version: 3 | 5 | 6"],
-		"links": ["https://haxe.org/manual/target-javascript-es6.html"]
-	},
-	{
-		"name": "JsEnumsAsArrays",
-		"define": "js_enums_as_arrays",
-		"doc": "Generate enum representation as array instead of as object.",
-		"platforms": ["js"]
-	},
-	{
-		"name": "JsUnflatten",
-		"define": "js_unflatten",
-		"doc": "Generate nested objects for packages and types.",
-		"platforms": ["js"]
-	},
-	{
-		"name": "JsSourceMap",
-		"define": "js_source_map",
-		"doc": "Generate JavaScript source map even in non-debug mode. Deprecated in favor of `-D source_map`.",
-		"platforms": ["js"]
-	},
-	{
-		"name": "SourceMap",
-		"define": "source_map",
-		"doc": "Generate source map for compiled files.",
-		"platforms": ["php", "js"]
-	},
-	{
 		"name": "Jvm",
 		"define": "jvm",
 		"doc": "Generate jvm directly.",
-		"platforms": ["java"]
-	},
-	{
-		"name": "JvmCompressionLevel",
-		"define": "jvm.compression-level",
-		"doc": "Set the compression level of the generated file between 0 (no compression) and 9 (highest compression). Default: 6",
-		"platforms": ["java"]
-	},
-	{
-		"name": "JvmDynamicLevel",
-		"define": "jvm.dynamic-level",
-		"doc": "Controls the amount of dynamic support code being generated. 0 = none, 1 = field read/write optimization (default), 2 = compile-time method closures",
 		"platforms": ["java"]
 	},
 	{
@@ -534,43 +430,6 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"define": "keep_old_output",
 		"doc": "Keep old source files in the output directory.",
 		"platforms": ["cs", "java"]
-	},
-	{
-		"name": "LoopUnrollMaxCost",
-		"define": "loop_unroll_max_cost",
-		"doc": "Maximum cost (number of expressions * iterations) before loop unrolling is canceled. (default: 250)",
-		"params": ["cost"]
-	},
-	{
-		"name": "LuaJit",
-		"define": "lua_jit",
-		"doc": "Enable the jit compiler for lua (version 5.2 only).",
-		"platforms": ["lua"]
-	},
-	{
-		"name": "LuaVanilla",
-		"define": "lua_vanilla",
-		"doc": "Generate code lacking compiled extern lib support (e.g. utf8).",
-		"platforms": ["lua"]
-	},
-	{
-		"name": "LuaVer",
-		"define": "lua_ver",
-		"doc": "The lua version to target.",
-		"platforms": ["lua"],
-		"params": ["version"]
-	},
-	{
-		"name": "Macro",
-		"define": "macro",
-		"doc": "Defined when code is compiled in the macro context.",
-		"links": ["https://haxe.org/manual/macro.html"],
-		"reserved": true
-	},
-	{
-		"name": "MacroTimes",
-		"define": "macro_times",
-		"doc": "Display per-macro timing when used with `--times`."
 	},
 	{
 		"name": "NetVer",
@@ -594,14 +453,619 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"params": ["name"]
 	},
 	{
+		"name": "NoRoot",
+		"define": "no_root",
+		"doc": "Generate top-level types into the `haxe.root` namespace.",
+		"platforms": ["cs"]
+	},
+	{
+		"name": "ReplaceFiles",
+		"define": "replace_files",
+		"doc": "GenCommon internal.",
+		"platforms": ["cs", "java"]
+	},
+	{
+		"name": "Unsafe",
+		"define": "unsafe",
+		"doc": "Allow unsafe code when targeting C#.",
+		"platforms": ["cs"]
+	},
+];
+
+// from https://github.com/HaxeFoundation/haxe/blob/development/src-json/define.json
+
+private final Defines:ReadOnlyArray<DefineData> = [
+	{
+		"name": "AbsolutePath",
+		"define": "absolute-path",
+		"doc": "Print absolute file path in trace output."
+	},
+	{
+		"name": "AdvancedTelemetry",
+		"define": "advanced-telemetry",
+		"doc": "Allow the SWF to be measured with Monocle tool.",
+		"platforms": ["flash"]
+	},
+	{
+		"name": "AnalyzerOptimize",
+		"define": "analyzer-optimize",
+		"doc": "Perform advanced optimizations."
+	},
+	{
+		"name": "AnalyzerTimes",
+		"define": "times.analyzer",
+		"deprecatedDefine": "analyzer-times",
+		"signatureNeutral": true,
+		"doc": "Record detailed timers for the analyzer",
+		"params": ["level: 0 | 1 | 2"]
+	},
+	{
+		"name": "AnnotateSource",
+		"define": "annotate-source",
+		"doc": "Add additional comments to generated source code.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "CheckXmlProxy",
+		"define": "check-xml-proxy",
+		"doc": "Check the used fields of the XML proxy."
+	},
+	{
+		"name": "CoreApi",
+		"define": "core-api",
+		"doc": "Defined in the core API context."
+	},
+	{
+		"name": "Cppia",
+		"define": "cppia",
+		"doc": "Generate cpp instruction assembly."
+	},
+	{
+		"name": "NoCppiaAst",
+		"define": "nocppiaast",
+		"doc": "Use legacy cppia generation."
+	},
+	{
+		"name": "Dce",
+		"define": "dce",
+		"doc": "Set the dead code elimination mode. (default: std)",
+		"params": ["mode: std | full | no"],
+		"defaultValue": "std",
+		"links": ["https://haxe.org/manual/cr-dce.html"]
+	},
+	{
+		"name": "DceDebug",
+		"define": "dce-debug",
+		"signatureNeutral": true,
+		"doc": "Show DCE log.",
+		"links": ["https://haxe.org/manual/cr-dce.html"]
+	},
+	{
+		"name": "Debug",
+		"define": "debug",
+		"doc": "Activated when compiling with -debug."
+	},
+	{
+		"name": "DisableHxbCache",
+		"define": "disable-hxb-cache",
+		"signatureNeutral": true,
+		"doc": "Use in-memory cache instead of hxb powered cache."
+	},
+	{
+		"name": "DisableHxbOptimizations",
+		"define": "disable-hxb-optimizations",
+		"signatureNeutral": true,
+		"doc": "Disable shortcuts used by hxb cache to speed up display requests."
+	},
+	{
+		"name": "EnableParallelism",
+		"define": "enable-parallelism",
+		"signatureNeutral": true,
+		"doc": "Enable experimental uses of parallelism in the compiler."
+	},
+	{
+		"name": "DisableUnicodeStrings",
+		"define": "disable-unicode-strings",
+		"doc": "Disable Unicode support in `String` type.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "Display",
+		"define": "display",
+		"signatureNeutral": true,
+		"doc": "Activated during completion.",
+		"links": ["https://haxe.org/manual/cr-completion.html"]
+	},
+	{
+		"name": "DisplayStdin",
+		"define": "display-stdin",
+		"signatureNeutral": true,
+		"doc": "Read the contents of a file specified in `--display` from standard input."
+	},
+	{
+		"name": "DllExport",
+		"define": "dll-export",
+		"doc": "GenCPP experimental linking.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "DocGen",
+		"define": "doc-gen",
+		"doc": "Do not perform any removal/change in order to correctly generate documentation."
+	},
+	{
+		"name": "Dump",
+		"define": "dump",
+		"signatureNeutral": true,
+		"doc": "Dump typed AST in dump subdirectory using specified mode or non-prettified default.",
+		"params": ["mode: pretty | record | position | legacy"]
+	},
+	{
+		"name": "DumpStage",
+		"define": "dump.stage",
+		"signatureNeutral": true,
+		"doc": "The compiler stage after which to generate the dump",
+		"params": ["stage: typing | casting | inlining | analyzing | dce"],
+		"defaultValue": "dce"
+	},
+	{
+		"name": "DumpPath",
+		"define": "dump-path",
+		"signatureNeutral": true,
+		"doc": "Path to generate dumps to (default: \"dump\").",
+		"defaultValue": "dump",
+		"params": ["path"]
+	},
+	{
+		"name": "DumpDependencies",
+		"define": "dump-dependencies",
+		"signatureNeutral": true,
+		"doc": "Dump the classes dependencies in a dump subdirectory."
+	},
+	{
+		"name": "DumpIgnoreVarIds",
+		"define": "dump-ignore-var-ids",
+		"signatureNeutral": true,
+		"doc": "Remove variable IDs from non-pretty dumps (helps with diff).",
+		"defaultValue": "1"
+	},
+	{
+		"name": "DynamicInterfaceClosures",
+		"define": "dynamic-interface-closures",
+		"doc": "Use slow path for interface closures to save space.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "EvalCallStackDepth",
+		"define": "eval-call-stack-depth",
+		"doc": "Set maximum call stack depth for eval. (default: 1000)",
+		"platforms": ["eval"],
+		"defaultValue": "1000",
+		"params": ["depth"]
+	},
+	{
+		"name": "EvalDebugger",
+		"define": "eval-debugger",
+		"doc": "Support debugger in macro/interp mode. Allows `host:port` value to open a socket. Implies eval-stack.",
+		"platforms": ["eval"]
+	},
+	{
+		"name": "EvalPrintDepth",
+		"define": "eval-print-depth",
+		"doc": "Set maximum print depth (before replacing with '<...>') for eval. (default: 5)",
+		"platforms": ["eval"],
+		"defaultValue": "5",
+		"params": ["depth"]
+	},
+	{
+		"name": "EvalPrettyPrint",
+		"define": "eval-pretty-print",
+		"doc": "Enable indented output for eval printing.",
+		"platforms": ["eval"]
+	},
+	{
+		"name": "EvalStack",
+		"define": "eval-stack",
+		"doc": "Record stack information in macro/interp mode.",
+		"platforms": ["eval"]
+	},
+	{
+		"name": "EvalTimes",
+		"define": "times.eval",
+		"deprecatedDefine": "eval-times",
+		"signatureNeutral": true,
+		"doc": "Record per-method execution times in macro/interp mode. Implies eval-stack.",
+		"platforms": ["eval"]
+	},
+	{
+		"name": "FailFast",
+		"define": "fail-fast",
+		"signatureNeutral": true,
+		"doc": "Abort compilation when first error occurs."
+	},
+	{
+		"name": "FilterTimes",
+		"define": "times.filter",
+		"deprecatedDefine": "filter-times",
+		"signatureNeutral": true,
+		"doc": "Record per-filter execution times upon --times."
+	},
+	{
+		"name": "Fdb",
+		"define": "fdb",
+		"doc": "Enable full flash debug infos for FDB interactive debugging.",
+		"platforms": ["flash"]
+	},
+	{
+		"name": "FileExtension",
+		"define": "file-extension",
+		"doc": "Output filename extension for cpp source code.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "FlashStrict",
+		"define": "flash-strict",
+		"doc": "More strict typing for flash target.",
+		"platforms": ["flash"]
+	},
+	{
+		"name": "FlashUseStage",
+		"define": "flash-use-stage",
+		"doc": "Keep the SWF library initial stage.",
+		"platforms": ["flash"]
+	},
+	{
+		"name": "ForceNativeProperty",
+		"define": "force-native-property",
+		"doc": "Tag all properties with `:nativeProperty` metadata for 3.1 compatibility.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "Haxe3Compat",
+		"define": "haxe3compat",
+		"doc": "Gives warnings about transition from Haxe 3.x to Haxe 4.0.",
+		"deprecated": "This flag is no longer supported in Haxe 5"
+	},
+	{
+		"name": "HaxeBoot",
+		"define": "haxe-boot",
+		"doc": "Give the name 'haxe' to the flash boot class instead of a generated name.",
+		"platforms": ["flash"]
+	},
+	{
+		"name": "HaxeVer",
+		"define": "haxe-ver",
+		"doc": "The current Haxe version value as decimal number. E.g. 3.407 for 3.4.7.",
+		"reserved": true
+	},
+	{
+		"name": "Haxe",
+		"define": "haxe",
+		"doc": "The current Haxe version value in SemVer format.",
+		"reserved": true
+	},
+	{
+		"name": "Haxe3",
+		"define": "haxe3",
+		"doc": "The current Haxe major version is >= 3.",
+		"defaultValue": "1",
+		"reserved": true
+	},
+	{
+		"name": "Haxe4",
+		"define": "haxe4",
+		"doc": "The current Haxe major version is >= 4.",
+		"defaultValue": "1",
+		"reserved": true
+	},
+	{
+		"name": "Haxe5",
+		"define": "haxe5",
+		"doc": "The current Haxe major version is >= 5.",
+		"defaultValue": "1",
+		"reserved": true
+	},
+	{
+		"name": "HaxeNext",
+		"define": "haxe-next",
+		"doc": "Enable experimental features that are meant to be released on next Haxe version."
+	},
+	{
+		"name": "HaxeOutputFile",
+		"define": "HAXE-OUTPUT-FILE",
+		"doc": "Force the full output name of the executable/library without library prefix and debug suffix.",
+		"platforms": ["cpp"],
+		"params": ["name"]
+	},
+	{
+		"name": "HaxeOutputPart",
+		"define": "HAXE-OUTPUT-PART",
+		"doc": "Output name of the executable/library. (default: main class name)",
+		"platforms": ["cpp"],
+		"params": ["name"]
+	},
+	{
+		"name": "Hlc",
+		"define": "hlc",
+		"doc": "Defined by compiler when using hl/c target.",
+		"platforms": ["hl"],
+		"reserved": true
+	},
+	{
+		"name": "HlVer",
+		"define": "hl-ver",
+		"doc": "The HashLink version to target. (default: 1.15.0)",
+		"platforms": ["hl"],
+		"params": ["version"]
+	},
+	{
+		"name": "HxbTimes",
+		"define": "times.hxb",
+		"deprecatedDefine": "hxb-times",
+		"signatureNeutral": true,
+		"doc": "Display hxb timing when used with `--times`."
+	},
+	{
+		"name": "HxbStats",
+		"define": "hxb.stats",
+		"signatureNeutral": true,
+		"doc": "Display some hxb related stats (only with compilation server)."
+	},
+	{
+		"name": "HxcppApiLevel",
+		"define": "hxcpp-api-level",
+		"doc": "Provided to allow compatibility between hxcpp versions.",
+		"platforms": ["cpp"],
+		"reserved": true
+	},
+	{
+		"name": "HxcppGcGenerational",
+		"define": "HXCPP-GC-GENERATIONAL",
+		"doc": "Experimental Garbage Collector.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppDebugger",
+		"define": "HXCPP-DEBUGGER",
+		"doc": "Include additional information for hxcpp-debugger.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppGcMoving",
+		"define": "HXCPP-GC-MOVING",
+		"doc": "Allow garbage collector to move memory to reduce fragmentation",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppGcSummary",
+		"define": "HXCPP-GC-SUMMARY",
+		"doc": "Print small profiling summary at end of program",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppGcDynamicSize",
+		"define": "HXCPP-GC-DYNAMIC-SIZE",
+		"doc": "Monitor GC times and expand memory working space if required",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppGcBigBlocks",
+		"define": "HXCPP-GC-BIG-BLOCKS",
+		"doc": "Allow working memory greater than 1 Gig",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppGcDebugLevel",
+		"define": "HXCPP-GC-DEBUG-LEVEL",
+		"doc": "Number 1-4 indicating additional debugging in GC",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppDebugLink",
+		"define": "HXCPP-DEBUG-LINK",
+		"doc": "Add symbols to final binary, even in release mode.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppStackTrace",
+		"define": "HXCPP-STACK-TRACE",
+		"doc": "Have valid function-level stack traces, even in release mode.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppStackLine",
+		"define": "HXCPP-STACK-LINE",
+		"doc": "Include line information in stack traces, even in release mode.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppCheckPointer",
+		"define": "HXCPP-CHECK-POINTER",
+		"doc": "Add null-pointer checks, even in release mode.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppProfiler",
+		"define": "HXCPP-PROFILER",
+		"doc": "Add profiler support",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppTelemetry",
+		"define": "HXCPP-TELEMETRY",
+		"doc": "Add telemetry support",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppCpp11",
+		"define": "HXCPP-CPP11",
+		"doc": "Use C++11 features and link libraries",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppVerbose",
+		"define": "HXCPP-VERBOSE",
+		"doc": "Print extra output from build tool.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppTimes",
+		"define": "HXCPP-TIMES",
+		"doc": "Show some basic profiling information",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppM32",
+		"define": "HXCPP-M32",
+		"doc": "Force 32-bit compile for current desktop",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppM64",
+		"define": "HXCPP-M64",
+		"doc": "Force 64-bit compile for current desktop",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppArm64",
+		"define": "HXCPP-ARM64",
+		"doc": "Compile arm-based devices for 64 bits",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppLinuxArm64",
+		"define": "HXCPP-LINUX-ARM64",
+		"doc": "Run on a linux ARM64 device",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "HxcppSmartStings",
+		"define": "hxcpp-smart-strings",
+		"doc": "Use wide strings in hxcpp. (Turned on by default unless `-D disable-unicode-strings` is specified.)",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "IncludePrefix",
+		"define": "include-prefix",
+		"doc": "Prepend path to generated include files.",
+		"platforms": ["cpp"]
+	},
+	{
+		"name": "Interp",
+		"define": "interp",
+		"doc": "The code is compiled to be run with `--interp`."
+	},
+	{
+		"name": "JsClassic",
+		"define": "js-classic",
+		"doc": "Don't use a function wrapper and strict mode in JS output.",
+		"platforms": ["js"]
+	},
+	{
+		"name": "JsEs",
+		"define": "js-es",
+		"doc": "Generate JS compliant with given ES standard version. (default: 5)",
+		"platforms": ["js"],
+		"params": ["version: 3 | 5 | 6"],
+		"links": ["https://haxe.org/manual/target-javascript-es6.html"]
+	},
+	{
+		"name": "JsEnumsAsArrays",
+		"define": "js-enums-as-arrays",
+		"doc": "Generate enum representation as array instead of as object.",
+		"platforms": ["js"]
+	},
+	{
+		"name": "JsGlobal",
+		"define": "js-global",
+		"doc": "Customizes the global object name.",
+		"platforms": ["js"]
+	},
+	{
+		"name": "JsUnflatten",
+		"define": "js-unflatten",
+		"doc": "Generate nested objects for packages and types.",
+		"platforms": ["js"]
+	},
+	{
+		"name": "JsSourceMap",
+		"define": "js-source-map",
+		"doc": "Generate JavaScript source map even in non-debug mode. Deprecated in favor of `-D source-map`.",
+		"platforms": ["js"]
+	},
+	{
+		"name": "SourceMap",
+		"define": "source-map",
+		"doc": "Generate source map for compiled files.",
+		"platforms": ["php", "js"]
+	},
+	{
+		"name": "JvmCompressionLevel",
+		"define": "jvm.compression-level",
+		"doc": "Set the compression level of the generated file between 0 (no compression) and 9 (highest compression). Default: 6",
+		"platforms": ["jvm"]
+	},
+	{
+		"name": "JvmDynamicLevel",
+		"define": "jvm.dynamic-level",
+		"doc": "Controls the amount of dynamic support code being generated. 0 = none, 1 = field read/write optimization (default), 2 = compile-time method closures",
+		"platforms": ["jvm"]
+	},
+	{
+		"name": "LoopUnrollMaxCost",
+		"define": "loop-unroll-max-cost",
+		"doc": "Maximum cost (number of expressions * iterations) before loop unrolling is canceled. (default: 250)",
+		"defaultValue": "250",
+		"params": ["cost"]
+	},
+	{
+		"name": "LuaJit",
+		"define": "lua-jit",
+		"doc": "Enable the jit compiler for lua (version 5.2 only).",
+		"platforms": ["lua"]
+	},
+	{
+		"name": "LuaVanilla",
+		"define": "lua-vanilla",
+		"doc": "Generate code lacking compiled extern lib support (e.g. utf8).",
+		"platforms": ["lua"]
+	},
+	{
+		"name": "LuaVer",
+		"define": "lua-ver",
+		"doc": "The lua version to target.",
+		"platforms": ["lua"],
+		"params": ["version"]
+	},
+	{
+		"name": "Macro",
+		"define": "macro",
+		"doc": "Defined when code is compiled in the macro context.",
+		"links": ["https://haxe.org/manual/macro.html"],
+		"reserved": true
+	},
+	{
+		"name": "MacroTimes",
+		"define": "times.macro",
+		"deprecatedDefine": "macro-times",
+		"signatureNeutral": true,
+		"doc": "Display per-macro timing when used with `--times`."
+	},
+	{
 		"name": "NekoSource",
-		"define": "neko_source",
+		"define": "neko-source",
 		"doc": "Output neko source instead of bytecode.",
 		"platforms": ["neko"]
 	},
 	{
+		"name": "NekoNoHaxelibPaths",
+		"define": "neko-no-haxelib-paths",
+		"doc": "Disable hard-coded Haxelib ndll paths.",
+		"platforms": ["neko"]
+	},
+	{
 		"name": "NekoV1",
-		"define": "neko_v1",
+		"define": "neko-v1",
 		"doc": "Keep Neko 1.x compatibility.",
 		"platforms": ["neko"]
 	},
@@ -614,18 +1078,20 @@ private final Defines:ReadOnlyArray<DefineData> = [
 	{
 		"name": "NoCompilation",
 		"define": "no-compilation",
+		"signatureNeutral": true,
 		"doc": "Disable final compilation.",
-		"platforms": ["cs", "java", "cpp", "hl"]
+		"platforms": ["cpp", "hl"]
 	},
 	{
 		"name": "NoDebug",
-		"define": "no_debug",
+		"define": "no-debug",
 		"doc": "Remove all debug macros from cpp output."
 	},
 	{
 		"name": "NoDeprecationWarnings",
 		"define": "no-deprecation-warnings",
-		"doc": "Do not warn if fields annotated with `@:deprecated` are used."
+		"doc": "Do not warn if fields annotated with `@:deprecated` are used.",
+		"deprecated": "Use -w to configure warnings. See https://haxe.org/manual/cr-warnings.html for more information."
 	},
 	{
 		"name": "NoFlashOverride",
@@ -635,41 +1101,35 @@ private final Defines:ReadOnlyArray<DefineData> = [
 	},
 	{
 		"name": "NoOpt",
-		"define": "no_opt",
+		"define": "no-opt",
 		"doc": "Disable optimizations."
 	},
 	{
 		"name": "NoInline",
-		"define": "no_inline",
+		"define": "no-inline",
 		"doc": "Disable inlining.",
 		"links": ["https://haxe.org/manual/class-field-inline.html"]
 	},
 	{
 		"name": "KeepInlinePositions",
-		"define": "keep_inline_positions",
+		"define": "keep-inline-positions",
 		"doc": "Don't substitute positions of inlined expressions with the position of the place of inlining.",
 		"links": ["https://haxe.org/manual/class-field-inline.html"]
 	},
 	{
-		"name": "NoRoot",
-		"define": "no_root",
-		"doc": "Generate top-level types into the `haxe.root` namespace.",
-		"platforms": ["cs"]
-	},
-	{
 		"name": "NoMacroCache",
-		"define": "no_macro_cache",
+		"define": "no-macro-cache",
 		"doc": "Disable macro context caching."
 	},
 	{
 		"name": "NoSwfCompress",
-		"define": "no_swf_compress",
+		"define": "no-swf-compress",
 		"doc": "Disable SWF output compression.",
 		"platforms": ["flash"]
 	},
 	{
 		"name": "NoTraces",
-		"define": "no_traces",
+		"define": "no-traces",
 		"doc": "Disable all trace calls."
 	},
 	{
@@ -681,47 +1141,47 @@ private final Defines:ReadOnlyArray<DefineData> = [
 	{
 		"name": "OldErrorFormat",
 		"define": "old-error-format",
-		"doc": "Use Haxe 3.x zero-based column error messages instead of new one-based format."
+		"doc": "Use Haxe 3.x zero-based column error messages instead of new one-based format.",
+		"deprecated": "OldErrorFormat has been removed in Haxe 5"
 	},
 	{
 		"name": "PhpPrefix",
-		"define": "php_prefix",
+		"define": "php-prefix",
 		"doc": "Root namespace for generated php classes. E.g. if compiled with`-D php-prefix=some.sub`, then all classes will be generated in `\\some\\sub` namespace.",
 		"platforms": ["php"],
 		"params": ["dot-separated namespace"]
 	},
 	{
 		"name": "PhpLib",
-		"define": "php_lib",
+		"define": "php-lib",
 		"doc": "Select the name for the php lib folder.",
 		"platforms": ["php"],
 		"params": ["folder name"]
 	},
 	{
 		"name": "PhpFront",
-		"define": "php_front",
+		"define": "php-front",
 		"doc": "Select the name for the php front file. (default: `index.php`)",
 		"platforms": ["php"],
 		"params": ["filename"]
 	},
 	{
 		"name": "PythonVersion",
-		"define": "python_version",
+		"define": "python-version",
 		"doc": "The python version to target. (default: 3.3)",
 		"platforms": ["python"],
 		"params": ["version"]
 	},
 	{
 		"name": "RealPosition",
-		"define": "real_position",
-		"doc": "Disables Haxe source mapping when targetting C#, removes position comments in Java and Php output.",
-		"platforms": ["cs", "java", "php"]
+		"define": "real-position",
+		"doc": "Removes position comments in Php output.",
+		"platforms": ["php"]
 	},
 	{
-		"name": "ReplaceFiles",
-		"define": "replace_files",
-		"doc": "GenCommon internal.",
-		"platforms": ["cs", "java"]
+		"name": "RetainUntypedMeta",
+		"define": "retain-untyped-meta",
+		"doc": "Prevents arbitrary expression metadata from being discarded upon typing."
 	},
 	{
 		"name": "Scriptable",
@@ -756,7 +1216,7 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"name": "StdEncodingUtf8",
 		"define": "std-encoding-utf8",
 		"doc": "Force utf8 encoding for stdin, stdout and stderr",
-		"platforms": ["java", "cs", "python"]
+		"platforms": ["python"]
 	},
 	{
 		"name": "Swc",
@@ -767,59 +1227,65 @@ private final Defines:ReadOnlyArray<DefineData> = [
 	},
 	{
 		"name": "SwfCompressLevel",
-		"define": "swf_compress_level",
+		"define": "swf-compress-level",
 		"doc": "Set the amount of compression for the SWF output.",
 		"platforms": ["flash"],
 		"params": ["level: 1-9"]
 	},
 	{
 		"name": "SwfDebugPassword",
-		"define": "swf_debug_password",
+		"define": "swf-debug-password",
 		"doc": "Set a password for debugging.",
 		"platforms": ["flash"],
 		"params": ["password"]
 	},
 	{
 		"name": "SwfDirectBlit",
-		"define": "swf_direct_blit",
+		"define": "swf-direct-blit",
 		"doc": "Use hardware acceleration to blit graphics.",
 		"platforms": ["flash"]
 	},
 	{
 		"name": "SwfGpu",
-		"define": "swf_gpu",
+		"define": "swf-gpu",
 		"doc": "Use GPU compositing features when drawing graphics.",
 		"platforms": ["flash"]
 	},
 	{
+		"name": "SwfHeader",
+		"define": "swf-header",
+		"doc": "define SWF header (width:height:fps:color)",
+		"platforms": ["flash"]
+	},
+	{
 		"name": "SwfMetadata",
-		"define": "swf_metadata",
+		"define": "swf-metadata",
 		"doc": "Include contents of the given file as metadata in the SWF.",
 		"platforms": ["flash"],
 		"params": ["file"]
 	},
 	{
 		"name": "SwfPreloaderFrame",
-		"define": "swf_preloader_frame",
+		"define": "swf-preloader-frame",
 		"doc": "Insert empty first frame in SWF.",
 		"platforms": ["flash"]
 	},
 	{
 		"name": "SwfProtected",
-		"define": "swf_protected",
+		"define": "swf-protected",
 		"doc": "Compile Haxe `private` as `protected` in the SWF instead of `public`.",
 		"platforms": ["flash"]
 	},
 	{
 		"name": "SwfScriptTimeout",
-		"define": "swf_script_timeout",
+		"define": "swf-script-timeout",
 		"doc": "Maximum ActionScript processing time before script stuck dialog box displays.",
 		"platforms": ["flash"],
 		"params": ["time in seconds"]
 	},
 	{
 		"name": "SwfUseDoAbc",
-		"define": "swf_use_doabc",
+		"define": "swf-use-doabc",
 		"doc": "Use `DoAbc` SWF-tag instead of `DoAbcDefine`.",
 		"platforms": ["flash"]
 	},
@@ -830,14 +1296,8 @@ private final Defines:ReadOnlyArray<DefineData> = [
 		"reserved": true
 	},
 	{
-		"name": "Unsafe",
-		"define": "unsafe",
-		"doc": "Allow unsafe code when targeting C#.",
-		"platforms": ["cs"]
-	},
-	{
 		"name": "UseNekoc",
-		"define": "use_nekoc",
+		"define": "use-nekoc",
 		"doc": "Use `nekoc` compiler instead of the internal one.",
 		"platforms": ["neko"]
 	},
@@ -855,12 +1315,47 @@ private final Defines:ReadOnlyArray<DefineData> = [
 	},
 	{
 		"name": "WarnVarShadowing",
-		"define": "warn_var_shadowing",
-		"doc": "Warn about shadowing variable declarations."
+		"define": "warn-var-shadowing",
+		"doc": "Warn about shadowing variable declarations.",
+		"deprecated": "Use -w to configure warnings. See https://haxe.org/manual/cr-warnings.html for more information."
 	},
 	{
 		"name": "NoTre",
-		"define": "no_tre",
+		"define": "no-tre",
 		"doc": "Disable tail recursion elimination."
+	},
+	{
+		"name": "MessageReporting",
+		"define": "message.reporting",
+		"signatureNeutral": true,
+		"doc": "Select message reporting mode for compiler output. (default: pretty)",
+		"defaultValue": "pretty",
+		"params": ["mode: classic | pretty | indent"]
+	},
+	{
+		"name": "MessageColor",
+		"define": "message.color",
+		"signatureNeutral": true,
+		"doc": "Enable ANSI color codes in message reporting."
+	},
+	{
+		"name": "MessageAbsolutePositions",
+		"define": "message.absolute-positions",
+		"signatureNeutral": true,
+		"doc": "Use absolute character positions instead of line/columns for message reporting."
+	},
+	{
+		"name": "MessageLogFile",
+		"define": "message.log-file",
+		"signatureNeutral": true,
+		"doc": "Path to a text file to write message reporting to, in addition to regular output."
+	},
+	{
+		"name": "MessageLogFormat",
+		"define": "message.log-format",
+		"signatureNeutral": true,
+		"doc": "Select message reporting mode for message log file. (default: indent)",
+		"defaultValue": "indent",
+		"params": ["format: classic | pretty | indent"]
 	}
 ];

--- a/src/haxeLanguageServer/protocol/DisplayPrinter.hx
+++ b/src/haxeLanguageServer/protocol/DisplayPrinter.hx
@@ -635,6 +635,7 @@ class DisplayPrinter {
 			case Python: "Python";
 			case Hl: "HashLink";
 			case Eval: "Eval";
+			default: '$platform'; // without default, C# is not detected correctly
 		}
 	}
 


### PR DESCRIPTION
Manually update based on https://github.com/HaxeFoundation/haxe/blob/development/src-json/define.json and

- Rename `default` to `defaultValue`
- Removed `DisplayDetails` (as only used by vshaxe and is deprecated in haxe5)
- Add more hl_ver
- Fix C# target not displayed correctly in the description

Note:
- If we're going to use https://github.com/vshaxe/haxe-language-server/pull/145 for all haxe >= 5, it can still provide fallback and invalid flags info (but it's less interesting because this need manual update)
- Not sure if signatureNeutral / deprecatedDefine etc need to be included
- The defines are unified to use `-` instead of `_` in haxe's define.json, this has not impact on `#if` completion because vshaxe doesn't support it for the moment. However, if using display/defines request we still receive unified `_`.