### PR TITLE
Prevent updateSingleFileCache parse hxml as hx code

### DIFF
--- a/src/haxeLanguageServer/features/haxe/refactoring/RefactorCache.hx
+++ b/src/haxeLanguageServer/features/haxe/refactoring/RefactorCache.hx
@@ -142,7 +142,9 @@ class RefactorCache {
 		final usageContext:UsageContext = makeUsageContext();
 		usageContext.fileName = uri;
 		try {
-			TraverseSources.collectIdentifierData(usageContext);
+			if (StringTools.endsWith(uri, ".hx")) {
+				TraverseSources.collectIdentifierData(usageContext);
+			}
 		} catch (e:Exception) {
 			#if debug
 			trace("failed to updateSingleFileCache: " + e);


### PR DESCRIPTION
Error message when opening a hxml file with comments (begin with `#`) (not print in release mode):

```
failed to updateSingleFileCache: failed to parse e:/Projects/test/test.hxml - ParserError: Unexpected # (e:/Projects/test/test.hxml:characters 48-48)
```