### PR TITLE
Reduce diagnostics on start, add option to disable diagnostics on open

### DIFF
--- a/src/haxeLanguageServer/Configuration.hx
+++ b/src/haxeLanguageServer/Configuration.hx
@@ -88,6 +88,7 @@ typedef UserConfig = {
 	var enableDiagnostics:Bool;
 	var enableServerView:Bool;
 	var enableSignatureHelpDocumentation:Bool;
+	var diagnosticsOnFileOpen:Bool;
 	var diagnosticsForAllOpenFiles:Bool;
 	var diagnosticsPathFilter:String;
 	var displayHost:Null<String>;
@@ -160,6 +161,7 @@ class Configuration {
 		enableDiagnostics: true,
 		enableServerView: false,
 		enableSignatureHelpDocumentation: true,
+		diagnosticsOnFileOpen: true,
 		diagnosticsForAllOpenFiles: true,
 		diagnosticsPathFilter: "${workspaceRoot}",
 		displayHost: null,

--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -431,6 +431,8 @@ class Context {
 		if (isUriSupported(uri)) {
 			activeEditor = uri;
 			documents.onDidOpenTextDocument(event);
+			if (config.user.diagnosticsOnFileOpen)
+				publishDiagnostics(uri);
 		}
 	}
 
@@ -502,6 +504,12 @@ class Context {
 		final document = documents.getHaxe(params.uri);
 		if (document == null) {
 			return;
+		}
+		// avoid running diagnostics twice when the document is initially opened (open + activate event)
+		final timeSinceOpened = haxe.Timer.stamp() - document.openTimestamp;
+		if (config.user.diagnosticsOnFileOpen && timeSinceOpened > 0.1) {
+			publishDiagnostics(params.uri);
+			invalidated.remove(activeEditor.toString());
 		}
 		updateActiveEditorPackage(activeEditor);
 	}

--- a/src/haxeLanguageServer/Context.hx
+++ b/src/haxeLanguageServer/Context.hx
@@ -404,8 +404,10 @@ class Context {
 				new WorkspaceSymbolsFeature(this);
 				new InlineValueFeature(this, refactorCache);
 
-				for (doc in documents) {
-					publishDiagnostics(doc.uri);
+				if (!config.user.buildCompletionCache) {
+					for (doc in documents) {
+						publishDiagnostics(doc.uri);
+					}
 				}
 				initialized = true;
 			});
@@ -413,7 +415,7 @@ class Context {
 			haxeServer.restart(reason, function() {
 				onServerStarted();
 				refactorCache.initClassPaths();
-				if (activeEditor != null) {
+				if (!config.user.buildCompletionCache && activeEditor != null) {
 					publishDiagnostics(activeEditor);
 				}
 			});
@@ -429,7 +431,6 @@ class Context {
 		if (isUriSupported(uri)) {
 			activeEditor = uri;
 			documents.onDidOpenTextDocument(event);
-			publishDiagnostics(uri);
 		}
 	}
 
@@ -501,12 +502,6 @@ class Context {
 		final document = documents.getHaxe(params.uri);
 		if (document == null) {
 			return;
-		}
-		// avoid running diagnostics twice when the document is initially opened (open + activate event)
-		final timeSinceOpened = haxe.Timer.stamp() - document.openTimestamp;
-		if (timeSinceOpened > 0.1) {
-			publishDiagnostics(params.uri);
-			invalidated.remove(activeEditor.toString());
 		}
 		updateActiveEditorPackage(activeEditor);
 	}


### PR DESCRIPTION
On a large macro heavy project, diagnostic can take 5-10s on each file.

Diagnostic on open file is typically slowing down other requests such as `go to definition`:
- With file A, B open, A contains some classes of B. Each time when we click on A and do `go to definition`, compiler wait until the end of diagnostic of file A before checking which file to go. Perform `go to definition` multiple times is very slow, and the diagnostic dosen't gives us any other useful information as file A didn't change at all.

Diagnostic on server start / restart is not useful when a completion cache is build on server start. It's better to rely on the full cache instead of diagnostic result at this time.