### PR TITLE
Var extraction fixes

### DIFF
--- a/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/ExtractVarFeature.hx
@@ -33,11 +33,14 @@ class ExtractVarFeature implements CodeActionContributor {
 		// only look at token at range start
 		final token = tokens.getTokenAtOffset(doc.offsetAt(range.start)) ?? return [];
 		switch token.tok {
-			case Const(_):
+			case Const(CIdent("is")):
+				return extractBinop(doc, tokens, uri, token, range);
+			case Const(_), Kwd(KwdNew):
 				final token = preDotToken(token);
-				if (TokenTreeUtils.isInFunctionScope(token))
+				final hasSelection = !range.isEmpty();
+				if (!hasSelection && TokenTreeUtils.isInFunctionScope(token))
 					return [];
-				if (isTypeHint(token))
+				if (isTypePosition(token))
 					return [];
 				// disallow full obj extraction when cursor is in `{nam|e: value}`
 				if (TokenTreeUtils.isAnonStructureField(token))
@@ -49,12 +52,65 @@ class ExtractVarFeature implements CodeActionContributor {
 			case BrOpen, BrClose if (TokenTreeUtils.isAnonStructure(token)):
 				final action:Null<CodeAction> = makeExtractVarAction(doc, tokens, uri, token, range);
 				return action == null ? [] : [action];
+			case BrOpen, BrClose:
+				// `{` or `}` of an anon function body — extract the whole arrow/function
+				final fn = TokenTreeUtils.getAnonFunctionFromBlock(token);
+				if (fn != null)
+					return extractAnonFunction(doc, tokens, uri, fn, range);
+				return [];
+			case Arrow:
+				// cursor on `->` — extract the whole `args -> body`
+				return extractAnonFunction(doc, tokens, uri, token, range);
+			case Kwd(KwdFunction) if (TokenTreeUtils.isAnonFunction(token)):
+				// cursor on `function` keyword of anon `function() { ... }`
+				return extractAnonFunction(doc, tokens, uri, token, range);
+			case POpen:
+				// `(` of arrow/anon-function args
+				final fn = TokenTreeUtils.getAnonFunctionFromPOpen(token);
+				if (fn != null)
+					return extractAnonFunction(doc, tokens, uri, fn, range);
+				final token = token.getFirstChild();
+				if (token != null && token.tok != PClose) {
+					final action:Null<CodeAction> = makeExtractVarAction(doc, tokens, uri, token, range);
+					return action == null ? [] : [action];
+				}
+				return [];
+			case Binop(OpAssign), Binop(OpAssignOp(_)):
+				return [];
+			case Binop(_):
+				// cursor on a binary operator (`||`, `&&`, `+`, etc)
+				// extract the whole binop expression
+				return extractBinop(doc, tokens, uri, token, range);
 			case BkOpen, BkClose:
 				final action:Null<CodeAction> = makeExtractVarAction(doc, tokens, uri, token, range);
 				return action == null ? [] : [action];
 			default:
 				return [];
 		}
+	}
+
+	function extractBinop(doc:HaxeDocument, tokens:TokenTreeManager, uri:DocumentUri, binop:TokenTree, range:Range):Array<CodeAction> {
+		final left = binop.parent ?? return [];
+		final left = preDotToken(left);
+		final right = binop.getFirstChild() ?? return [];
+		final lastRight = TokenTreeCheckUtils.getLastToken(right) ?? right;
+		final start = tokens.getPos(left).min;
+		final end = tokens.getPos(lastRight).max;
+		final binopRange = doc.rangeAt(start, end);
+		final action:Null<CodeAction> = makeExtractVarAction(doc, tokens, uri, left, binopRange);
+		return action == null ? [] : [action];
+	}
+
+	function extractAnonFunction(doc:HaxeDocument, tokens:TokenTreeManager, uri:DocumentUri, fnRoot:TokenTree, range:Range):Array<CodeAction> {
+		// for arrow: range covers `args -> body` (args = Arrow.parent: POpen or single arg ident).
+		// for `function`: range covers `function (...) { ... }` (the whole KwdFunction subtree).
+		final startToken = if (fnRoot.tok == Arrow) fnRoot.parent ?? return [] else fnRoot;
+		final lastToken = getLastNonCommaToken(fnRoot) ?? fnRoot;
+		final start = tokens.getPos(startToken).min;
+		final end = tokens.getPos(lastToken).max;
+		final fnRange = doc.rangeAt(start, end);
+		final action:Null<CodeAction> = makeExtractVarAction(doc, tokens, uri, fnRoot, fnRange);
+		return action == null ? [] : [action];
 	}
 
 	function isFieldAssign(token:TokenTree):Bool {
@@ -67,12 +123,17 @@ class ExtractVarFeature implements CodeActionContributor {
 		}
 	}
 
-	function isTypeHint(token:TokenTree):Bool {
+	function isTypePosition(token:TokenTree):Bool {
 		var parent:Null<TokenTree> = token.parent;
 		while (parent != null) {
 			switch parent.tok {
-				case DblDot: // not anon structure
-					return parent.parent?.parent?.tok != BrOpen;
+				case DblDot:
+					return switch TokenTreeCheckUtils.getColonType(parent) {
+						case TypeHint, TypeCheck: true;
+						case _: false;
+					}
+				case Const(CIdent("is")):
+					return true;
 				default:
 			}
 			token = parent;
@@ -81,23 +142,46 @@ class ExtractVarFeature implements CodeActionContributor {
 		return false;
 	}
 
+	function lastDotName(token:Null<TokenTree>):String {
+		// last ident of a dot-chain (`obj.foo.bar` -> `bar`, `new pkg.Foo()` -> `Foo`)
+		var tok = token;
+		while (tok != null) {
+			final child = tok.getFirstChild();
+			if (child != null && (child.tok == Dot || child.tok == QuestionDot))
+				tok = child.getFirstChild();
+			else
+				break;
+		}
+		if (tok == null)
+			return "value";
+		return TokenTreeCheckUtils.getName(tok) ?? "value";
+	}
+
 	function makeExtractVarAction(doc:HaxeDocument, tokens:TokenTreeManager, uri:DocumentUri, token:TokenTree, range:Range):Null<CodeAction> {
 		// use token at the selection end for `foo = Type.foo` names
 		final endToken:Null<TokenTree> = tokens.getTokenAtOffset(doc.offsetAt(range.end)) ?? token;
-		var text = switch endToken.tok {
-			case Const(CString(s)): s;
-			case Const(CInt(v, s)): s ?? "value";
-			case Const(CFloat(f, s)): s ?? "value";
-			case BrOpen, BrClose: "obj";
-			case BkOpen, BkClose: "arr";
-			case Const(CIdent(s)): s ?? "value";
-			case _: "value";
+		var text = switch token.tok {
+			case Arrow, Kwd(KwdFunction): "callback";
+			case Kwd(KwdNew): lastDotName(token.getFirstChild());
+			case Const(CIdent(_)) if (range.isEmpty()): lastDotName(token);
+			case _: switch endToken.tok {
+					case Const(CString(s)): s;
+					case Const(CInt(v, s)): s ?? "value";
+					case Const(CFloat(f, s)): s ?? "value";
+					case BrOpen, BrClose: "obj";
+					case BkOpen, BkClose: "arr";
+					case Const(CIdent(s)): s ?? "value";
+					case _: "value";
+				}
 		}
 		// generate a var name
 		var name:String = ~/[^A-Za-z0-9]/g.replace(text, "_");
-		name = ~/^[0-9]/g.replace(name, "_");
 		name = ~/_+/g.replace(name, "_");
 		name = ~/(^_|_$)/g.replace(name, "");
+		if (~/^[0-9]/.match(name))
+			name = "_" + name;
+		if (name.length > 50)
+			name = name.substr(0, 50);
 		// detect PascalCase and convert to camelCase
 		if (name.length > 1 && name.charAt(1).toLowerCase() == name.charAt(1)) {
 			name = name.charAt(0).toLowerCase() + name.substr(1);
@@ -110,8 +194,7 @@ class ExtractVarFeature implements CodeActionContributor {
 		final parent:Null<TokenTree> = findParentInLocalScope(token);
 		if (parent == null)
 			return null;
-		// trace("parent: ", parent);
-		final extractionRange = range.isEmpty() ? getExtractionRange(doc, token) : range;
+		final extractionRange = range.isEmpty() ? getExtractionRange(doc, token) : trimSelectionRange(doc, tokens, range);
 		if (extractionRange == null)
 			return null;
 		final fullText = doc.getText(extractionRange);
@@ -158,7 +241,14 @@ class ExtractVarFeature implements CodeActionContributor {
 		var parent:Null<TokenTree> = token.parent;
 		while (parent != null) {
 			switch parent.tok {
-				case Kwd(KwdFunction | KwdCase | KwdFor):
+				// inside case "block"
+				case DblDot if (TokenTreeCheckUtils.getColonType(parent) == SwitchCase):
+					return token;
+				// case if-guards
+				case Kwd(KwdCase):
+					final parent = parent.access().findParent(helper -> helper?.token.tok.match(Kwd(KwdSwitch)));
+					return parent?.token;
+				case Kwd(KwdFunction | KwdFor):
 					return null;
 				case BrOpen:
 					if (!TokenTreeUtils.isAnonStructure(parent))
@@ -169,6 +259,16 @@ class ExtractVarFeature implements CodeActionContributor {
 			parent = parent.parent;
 		}
 		return null;
+	}
+
+	function trimSelectionRange(doc:HaxeDocument, tokens:TokenTreeManager, range:Range):Range {
+		// drop `;` from the end
+		final endOffset = doc.offsetAt(range.end);
+		final endToken = tokens.getTokenAtOffset(endOffset);
+		if (endToken != null && endToken.tok == Semicolon && tokens.getPos(endToken).max == endOffset) {
+			return {start: range.start, end: doc.positionAt(tokens.getPos(endToken).min)};
+		}
+		return range;
 	}
 
 	function getExtractionRange(doc:HaxeDocument, token:TokenTree):Null<Range> {
@@ -230,16 +330,17 @@ class ExtractVarFeature implements CodeActionContributor {
 					if (parent.parent?.isCIdent() == true) {
 						parent = parent.parent ?? return [];
 					}
+				case BrOpen:
+					final first = token.getFirstChild();
+					final hasDot = first?.tok == Dot || first?.tok == QuestionDot;
+					final last = hasDot ? first : token;
+					return [token, getLastNonCommaToken(last)];
 				case DblDot, Binop(_), Kwd(_):
 					switch parent.tok {
 						case Kwd(KwdNew | KwdVar | KwdFinal):
 							return [];
 						case _:
-							// end of a.b expr is inside of Dot
-							final first = token.getFirstChild();
-							final hasDot = first?.tok == Dot || first?.tok == QuestionDot;
-							final last = hasDot ? first : token;
-							return [token, getLastNonCommaToken(last)];
+							return [token, getValueEndToken(token)];
 					}
 				case POpen, BkOpen:
 					final endBracket:tokentree.TokenTreeDef = switch parent.tok {
@@ -254,16 +355,14 @@ class ExtractVarFeature implements CodeActionContributor {
 						return [];
 					if (firstChild == null)
 						return tokens;
-					final hasDot = firstChild.tok == Dot || firstChild.tok == QuestionDot;
-					final isCall = firstChild.tok == POpen;
-					final isNew = token.tok.match(Kwd(KwdNew));
-					var lastParent = (hasDot || isCall || isNew) ? firstChild : token;
-					var last = getLastToken(lastParent) ?? return tokens;
-					if (last.tok.match(Comma | Binop(_))) {
-						last = last.parent ?? return tokens;
-					}
+					final last = getValueEndToken(token) ?? return tokens;
 					tokens.push(last);
 					return tokens;
+				case Question:
+					// ternary branch `cond ? a : b` — extract just this branch's value
+					return [token, getValueEndToken(token)];
+				case Unop(OpNot):
+					return [token, getValueEndToken(token)];
 				default:
 			}
 			token = parent;
@@ -276,6 +375,25 @@ class ExtractVarFeature implements CodeActionContributor {
 		if (token == null)
 			return null;
 		return TokenTreeCheckUtils.getLastToken(token);
+	}
+
+	function getValueEndToken(token:TokenTree):Null<TokenTree> {
+		final children = token.children;
+		if (children == null || children.length <= 0)
+			return token;
+		final lastChild = children[children.length - 1];
+		final trailingOp = switch lastChild.tok {
+			case Binop(_), Question, Const(CIdent("is")), Comma, Semicolon: true;
+			case DblDot: TokenTreeCheckUtils.getColonType(lastChild) == TypeCheck;
+			case _: false;
+		}
+		if (trailingOp) {
+			// value is just the head token (e.g. `a` in `a ?? b`)
+			if (children.length == 1)
+				return token;
+			return getValueEndToken(children[children.length - 2]);
+		}
+		return getValueEndToken(lastChild);
 	}
 
 	function getLastNonCommaToken(token:Null<TokenTree>):Null<TokenTree> {

--- a/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/TokenTreeUtils.hx
@@ -50,6 +50,8 @@ class TokenTreeUtils {
 	public static function isAnonStructure(brToken:TokenTree):Bool {
 		if (brToken.tok == BrClose)
 			brToken = brToken.parent ?? return false;
+		if (brToken.tok != BrOpen)
+			return false;
 		final first = brToken?.getFirstChild() ?? return false;
 		final colon = first.getFirstChild() ?? return false;
 		if (colon.tok.match(DblDot) && !colon.nextSibling?.tok.match(Semicolon)) {
@@ -64,5 +66,57 @@ class TokenTreeUtils {
 			return false;
 		final colon = token.getFirstChild() ?? return false;
 		return colon.tok.match(DblDot);
+	}
+
+	public static function isAnonFunction(kwdFunction:TokenTree):Bool {
+		if (!kwdFunction.tok.match(Kwd(KwdFunction)))
+			return false;
+		// first child is POpen, no name between `function` and `(`
+		final first = kwdFunction.getFirstChild() ?? return false;
+		return first.tok == POpen;
+	}
+
+	/**
+		If `brToken` (`BrOpen` or `BrClose`) is the body block of an arrow function or anon function.
+		Returns root token of that function (`Arrow` or `Kwd(KwdFunction)`) or `null`.
+	**/
+	public static function getAnonFunctionFromBlock(brToken:TokenTree):Null<TokenTree> {
+		var brOpen = brToken;
+		if (brOpen.tok == BrClose)
+			brOpen = brOpen.parent ?? return null;
+		if (brOpen.tok != BrOpen)
+			return null;
+		final parent = brOpen.parent ?? return null;
+		if (parent.tok == Arrow)
+			return parent;
+		// anon function: BrOpen.parent = POpen, POpen.parent = KwdFunction
+		if (parent.tok == POpen) {
+			final grand = parent.parent;
+			if (grand != null && isAnonFunction(grand))
+				return grand;
+		}
+		return null;
+	}
+
+	/**
+		If `pOpen` is the argument list of an arrow or anon function.
+		Returns root token of that function (`Arrow` or `Kwd(KwdFunction)`) or `null`.
+	**/
+	public static function getAnonFunctionFromPOpen(pOpen:TokenTree):Null<TokenTree> {
+		if (pOpen.tok != POpen)
+			return null;
+		// arrow args: POpen has Arrow as a child (last sibling after PClose)
+		final children = pOpen.children;
+		if (children != null) {
+			for (child in children) {
+				if (child.tok == Arrow)
+					return child;
+			}
+		}
+		// anon function args: POpen.parent is KwdFunction, and POpen is the first child
+		final parent = pOpen.parent;
+		if (parent != null && isAnonFunction(parent) && parent.getFirstChild() == pOpen)
+			return parent;
+		return null;
 	}
 }

--- a/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
+++ b/src/haxeLanguageServer/features/haxe/codeAction/diagnostics/MissingFieldsActions.hx
@@ -41,12 +41,12 @@ class MissingFieldsActions {
 				if (classToken == null) {
 					moduleLevelField = true;
 					final lastPos = document.content.length - 1;
-					rangeFieldInsertion = document.rangeAt(lastPos, lastPos, Utf8);
+					rangeFieldInsertion = document.rangeAt(lastPos, lastPos);
 				} else {
 					final pos = tokens.getPos(classToken);
-					rangeClass = document.rangeAt(pos.min, pos.min, Utf8);
+					rangeClass = document.rangeAt(pos.min, pos.min);
 					final pos = tokens.getTreePos(classToken);
-					rangeFieldInsertion = document.rangeAt(pos.max - 1, pos.max - 1, Utf8);
+					rangeFieldInsertion = document.rangeAt(pos.max - 1, pos.max - 1);
 				}
 			case _:
 				return [];

--- a/test/codeActions/ExtractVarTest.hx
+++ b/test/codeActions/ExtractVarTest.hx
@@ -5,6 +5,7 @@ import haxeLanguageServer.features.haxe.codeAction.ExtractVarFeature;
 @:access(haxeLanguageServer.features.haxe.codeAction.ExtractVarFeature)
 class ExtractVarTest extends DisplayTestCase {
 	/**
+		// абвг
 		class Main {
 			function main() {
 				var foo = "bar{-1-}";
@@ -13,6 +14,7 @@ class ExtractVarTest extends DisplayTestCase {
 			}
 		}
 		---
+		// абвг
 		class Main {
 			function main() {
 				final bar = "bar";
@@ -121,6 +123,408 @@ class ExtractVarTest extends DisplayTestCase {
 		applyTextEdit(actions[0].edit);
 		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(2).toRange());
 		applyTextEdit(actions[0].edit);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			if (obj.isTrue()) {
+				game.st{-1-}art(function() {});
+			} else {}
+		}
+		---
+		function main() {
+			if (obj.isTrue()) {
+				final start = game.start(function() {});
+				start;
+			} else {}
+		}
+	**/
+	function testStatementInBlock():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function call():Any {
+			if (obj.isTrue() || obj.sub.is{-1-}True()) {
+				return {a: () -> {}};
+			} else if (obj.nope) {
+				return {a: () -> {}};
+			}
+		}
+		---
+		function call():Any {
+			final isTrue = obj.sub.isTrue();
+			if (obj.isTrue() || isTrue) {
+				return {a: () -> {}};
+			} else if (obj.nope) {
+				return {a: () -> {}};
+			}
+		}
+	**/
+	function testSecondIfCond():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			obj.sub.delayed(1000, () ->{-1-} {
+				foo.value = 1;
+			});
+			obj.sub.delayed(1000, () -> {
+				foo.value = 2;
+			}{-2-});
+			obj.sub.delayed({a: [1, {}]}, funct{-3-}ion() {
+				foo.value = 3;
+			});
+		}
+		---
+		function main() {
+			final callback = () -> {
+				foo.value = 1;
+			};
+			obj.sub.delayed(1000, callback);
+			final callback = () -> {
+				foo.value = 2;
+			};
+			obj.sub.delayed(1000, callback);
+			final callback = function() {
+				foo.value = 3;
+			};
+			obj.sub.delayed({a: [1, {}]}, callback);
+		}
+	**/
+	function testExtractAnonFunction():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(3).toRange());
+		applyTextEdit(actions[0].edit);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(2).toRange());
+		applyTextEdit(actions[0].edit);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function call():Bool {
+			if (obj.isTrue() {-1-}|| obj.sub.isFalse) {
+				return true;
+			}
+			return false;
+		}
+		---
+		function call():Bool {
+			final isFalse = obj.isTrue() || obj.sub.isFalse;
+			if (isFalse) {
+				return true;
+			}
+			return false;
+		}
+	**/
+	function testExtractBinop():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			var last = fo{-1-}o(arr) ?? null;
+		}
+		---
+		function main() {
+			final foo = foo(arr);
+			var last = foo ?? null;
+		}
+	**/
+	function testExtractCallBeforeBinop():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			if (obj.f{-1-}oo == 200) {}
+		}
+		---
+		function main() {
+			final foo = obj.foo;
+			if (foo == 200) {}
+		}
+	**/
+	function testExtractDottedBeforeBinop():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			if ({-1-}obj.isTrue() || obj.sub.isFalse{-2-}) {}
+		}
+		---
+		function main() {
+			final isFalse = obj.isTrue() || obj.sub.isFalse;
+			if (isFalse) {}
+		}
+	**/
+	function testExtractIfConditionRangeWithParens():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, range(1, 2));
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			{-1-}bgObjects.add(trigger.obj);{-2-}
+		}
+		---
+		function main() {
+			final value = bgObjects.add(trigger.obj);
+			value;
+		}
+	**/
+	function testExtractSemicolonTrim():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, range(1, 2));
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			var x:I{-1-}nt = getValue();
+			var ok = foo(arr) is Dyn{-2-}amic;
+			foo((v : I{-3-}nt));
+		}
+	**/
+	function testNoExtractOnTypes():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		eq(0, feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange()).length);
+		eq(0, feature.extractVar(ctx.doc, ctx.uri, pos(2).toRange()).length);
+		eq(0, feature.extractVar(ctx.doc, ctx.uri, pos(3).toRange()).length);
+	}
+
+	/**
+		function main() {
+			foo((v{-1-} : Any));
+		}
+		---
+		function main() {
+			final v = v;
+			foo((v : Any));
+		}
+	**/
+	function testTypeCheck():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			foo((ar{-1-}r[0] : Any));
+		}
+		---
+		function main() {
+			final arr = arr[0];
+			foo((arr : Any));
+		}
+	**/
+	function testTypeCheckArrayAccess():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		// extract the value `arr[0]`, keeping the `: Any` check in place
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			var last = true ? fo{-1-}o(arr) : false;
+		}
+		---
+		function main() {
+			final foo = foo(arr);
+			var last = true ? foo : false;
+		}
+	**/
+	function testExtractTernaryBranch():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			var last = isF{-1-}oo() ? foo(arr) : false;
+		}
+		---
+		function main() {
+			final isFoo = isFoo();
+			var last = isFoo ? foo(arr) : false;
+		}
+	**/
+	function testExtractTernaryCond():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			var x = "foo" i{-1-}s String;
+			var y = "f{-2-}oo" is String;
+		}
+		---
+		function main() {
+			final string = "foo" is String;
+			var x = string;
+			final foo = "foo";
+			var y = foo is String;
+		}
+	**/
+	function testExtractIsOperator():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(2).toRange());
+		applyTextEdit(actions[0].edit);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			var b = !isR{-1-}eady();
+		}
+		---
+		function main() {
+			final isReady = isReady();
+			var b = !isReady;
+		}
+	**/
+	function testExtractUnaryOperand():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			send(Colors.Bl{-1-}ack, null);
+			obj.then(functi{-2-}on(res) {}, null);
+		}
+		---
+		function main() {
+			final black = Colors.Black;
+			send(black, null);
+			final callback = function(res) {};
+			obj.then(callback, null);
+		}
+	**/
+	function testExtractArgWithTrailingComma():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final b:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(2).toRange());
+		applyTextEdit(b[0].edit);
+		final a:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(a[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			switch x {
+				case Dot, Question:
+					if (parent.parent?.isCId{-1-}ent() == true) {}
+				default:
+			}
+		}
+		---
+		function main() {
+			switch x {
+				case Dot, Question:
+					final isCIdent = parent.parent?.isCIdent();
+					if (isCIdent == true) {}
+				default:
+			}
+		}
+	**/
+	function testExtractInSwitchCase():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			switch x {
+				case Dot, Question if (foo ={-1-}= true):
+				default:
+			}
+		}
+		---
+		function main() {
+			final value = foo == true;
+			switch x {
+				case Dot, Question if (value):
+				default:
+			}
+		}
+	**/
+	function testExtractSwitchCaseGuard():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			var x = ne{-1-}w Foo();
+		}
+		---
+		function main() {
+			final foo = new Foo();
+			var x = foo;
+		}
+	**/
+	function testExtractNewOnKeyword():Void {
+		final feature = new ExtractVarFeature(ctx.context);
+		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
+		applyTextEdit(actions[0].edit);
+		eq(ctx.result, ctx.doc.content);
+	}
+
+	/**
+		function main() {
+			trace(o{-1-}bj?.foo.bar);
+		}
+		---
+		function main() {
+			final bar = obj?.foo.bar;
+			trace(bar);
+		}
+	**/
+	function testExtractNameFromLastField():Void {
+		final feature = new ExtractVarFeature(ctx.context);
 		final actions:Array<CodeAction> = feature.extractVar(ctx.doc, ctx.uri, pos(1).toRange());
 		applyTextEdit(actions[0].edit);
 		eq(ctx.result, ctx.doc.content);


### PR DESCRIPTION
Fixing most broken extraction cases.
Some things for future:
- `var a = -2|00 + 100;` -> `-200` cannot be extracted, maybe tokentree position problem
- `for (i in 0...arr.len|gth)` - `for` body still ignored for now

Also broken position fix for missing field generation.