### PR TITLE
Update snippet for Kate config in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ There's a large amount of language client plugins for (Neo)vim, but the best cho
 
 ### Usage with Kate
 
-Go to configure Kate (`Ctrl+Shift+,`) » `LSP Client` » `User Server Settings` » Add the following snippet to the JSON config within the `servers` object. Don't forget to change the path to the LSP server.
+Go to configure Kate (`Ctrl+Shift+,`) » `LSP Client` » `User Server Settings` » Add the following snippet to the JSON config within the `servers` object. Don't forget to change the path to the LSP server and hxml file name.
 
 ```json
 "haxe": {
     "command": ["node", "<path-to-server.js>"],
-    "rootIndicationFileNames": ["*.hx", "*.hxml"],
+    "rootIndicationFilePatterns": ["*.hxml"],
     "url": "https://github.com/vshaxe/haxe-language-server",
     "initializationOptions": {"displayArguments": ["build.hxml"]},
     "settings": {"haxe": {"buildCompletionCache": true}},


### PR DESCRIPTION
Hello!

The snippet for kate config in the readme for me results in an error:
```
[16:15:22 ￼ LSP Server Log] haxe@C:/Users/lampy
Failed - try fixing the error(s) and restarting the language server:
Error: Could not process argument ./build.hxml (file not found)
Package name must not be empty
```

First, globs go to "rootIndicationFilePatterns" key. Then, the sever keeps looking for build.hxml relative to .hx files in sources dir which fails and stops completion from working. I also tried changing the order of the parameters but it doesn't seem to matter, so I removed them. The only problem with it is that completin no longer activates for sources without hxml file.

With this, I get working completion including haxelib packages. The original either doesn't work besides keyword completion, or occasionally works without packages (guess it somehow detects haxe but misses hxml).

Another possible fix is to set working dir as `"root": "."` instead of indicatorFileNames, it also works for me, after opening the folder as a project.